### PR TITLE
Drkey feature PR1

### DIFF
--- a/go/lib/drkey/BUILD.bazel
+++ b/go/lib/drkey/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "db.go",
+        "drkey.go",
+        "epoch.go",
+        "level1.go",
+        "level2.go",
+        "secret_value.go",
+        "suite.go",
+    ],
+    importpath = "github.com/scionproto/scion/go/lib/drkey",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/infra/modules/db:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/util:go_default_library",
+        "@org_golang_x_crypto//pbkdf2:go_default_library",
+    ],
+)

--- a/go/lib/drkey/BUILD.bazel
+++ b/go/lib/drkey/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -20,5 +20,14 @@ go_library(
         "//go/lib/scrypto:go_default_library",
         "//go/lib/util:go_default_library",
         "@org_golang_x_crypto//pbkdf2:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["secret_value_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/lib/common:go_default_library",
     ],
 )

--- a/go/lib/drkey/BUILD.bazel
+++ b/go/lib/drkey/BUILD.bazel
@@ -9,13 +9,11 @@ go_library(
         "level1.go",
         "level2.go",
         "secret_value.go",
-        "suite.go",
     ],
     importpath = "github.com/scionproto/scion/go/lib/drkey",
     visibility = ["//visibility:public"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/infra/modules/db:go_default_library",
         "//go/lib/scrypto:go_default_library",
         "//go/lib/util:go_default_library",
@@ -28,6 +26,6 @@ go_test(
     srcs = ["secret_value_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//go/lib/common:go_default_library",
+        "//go/lib/xtest:go_default_library",
     ],
 )

--- a/go/lib/drkey/db.go
+++ b/go/lib/drkey/db.go
@@ -1,0 +1,46 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"context"
+	"io"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/infra/modules/db"
+)
+
+type BaseDB interface {
+	io.Closer
+	db.LimitSetter
+}
+
+// Lvl1DB is the drkey database interface for level 1.
+type Lvl1DB interface {
+	BaseDB
+	GetLvl1Key(ctx context.Context, key Lvl1Meta, valTime uint32) (Lvl1Key, error)
+	InsertLvl1Key(ctx context.Context, key Lvl1Key) error
+	RemoveOutdatedLvl1Keys(ctx context.Context, cutoff uint32) (int64, error)
+	GetLvl1SrcASes(ctx context.Context) ([]addr.IA, error)
+	GetValidLvl1SrcASes(ctx context.Context, valTime uint32) ([]addr.IA, error)
+}
+
+// Lvl2DB is the drkey database interface for level 2.
+type Lvl2DB interface {
+	BaseDB
+	GetLvl2Key(ctx context.Context, key Lvl2Meta, valTime uint32) (Lvl2Key, error)
+	InsertLvl2Key(ctx context.Context, key Lvl2Key) error
+	RemoveOutdatedLvl2Keys(ctx context.Context, cutoff uint32) (int64, error)
+}

--- a/go/lib/drkey/db.go
+++ b/go/lib/drkey/db.go
@@ -22,6 +22,7 @@ import (
 	"github.com/scionproto/scion/go/lib/infra/modules/db"
 )
 
+// BaseDB defines basic interface
 type BaseDB interface {
 	io.Closer
 	db.LimitSetter

--- a/go/lib/drkey/drkey.go
+++ b/go/lib/drkey/drkey.go
@@ -1,0 +1,26 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+// DRKey represents a raw binary key
+type DRKey common.RawBytes
+
+func (k DRKey) String() string {
+	return "[redacted key]"
+}

--- a/go/lib/drkey/drkey.go
+++ b/go/lib/drkey/drkey.go
@@ -14,13 +14,16 @@
 
 package drkey
 
-import (
-	"github.com/scionproto/scion/go/lib/common"
-)
+import "bytes"
 
 // DRKey represents a raw binary key
-type DRKey common.RawBytes
+type DRKey []byte
 
 func (k DRKey) String() string {
 	return "[redacted key]"
+}
+
+// Equal returns true if both DRKeys are identical
+func (k DRKey) Equal(other DRKey) bool {
+	return bytes.Compare(k, other) == 0
 }

--- a/go/lib/drkey/epoch.go
+++ b/go/lib/drkey/epoch.go
@@ -17,30 +17,32 @@ package drkey
 import (
 	"time"
 
+	"github.com/scionproto/scion/go/lib/scrypto"
 	"github.com/scionproto/scion/go/lib/util"
 )
 
 // Epoch represents a validity period.
-// TODO use Validity Periods https://github.com/scionproto/scion/pull/2842/files
 type Epoch struct {
-	Begin time.Time
-	End   time.Time
+	Validity scrypto.Validity
 }
 
 // Equal returns true if both Epochs are identical.
 func (e Epoch) Equal(other Epoch) bool {
-	return e.Begin == other.Begin && e.End == other.End
+	return e.Validity.NotBefore.Time == other.Validity.NotBefore.Time &&
+		e.Validity.NotAfter.Time == other.Validity.NotAfter.Time
 }
 
 // NewEpoch constructs an Epoch from its uint32 encoded begin and end parts.
 func NewEpoch(begin, end uint32) Epoch {
 	return Epoch{
-		Begin: util.SecsToTime(begin),
-		End:   util.SecsToTime(end),
+		scrypto.Validity{
+			NotBefore: util.UnixTime{Time: util.SecsToTime(begin)},
+			NotAfter:  util.UnixTime{Time: util.SecsToTime(end)},
+		},
 	}
 }
 
 // Contains indicates whether the time point is inside this Epoch.
 func (e *Epoch) Contains(t time.Time) bool {
-	return !e.Begin.After(t) && e.End.After(t)
+	return e.Validity.Contains(t)
 }

--- a/go/lib/drkey/epoch.go
+++ b/go/lib/drkey/epoch.go
@@ -23,13 +23,13 @@ import (
 
 // Epoch represents a validity period.
 type Epoch struct {
-	Validity scrypto.Validity
+	scrypto.Validity
 }
 
 // Equal returns true if both Epochs are identical.
 func (e Epoch) Equal(other Epoch) bool {
-	return e.Validity.NotBefore.Time == other.Validity.NotBefore.Time &&
-		e.Validity.NotAfter.Time == other.Validity.NotAfter.Time
+	return e.NotBefore.Time == other.NotBefore.Time &&
+		e.NotAfter.Time == other.NotAfter.Time
 }
 
 // NewEpoch constructs an Epoch from its uint32 encoded begin and end parts.
@@ -44,5 +44,5 @@ func NewEpoch(begin, end uint32) Epoch {
 
 // Contains indicates whether the time point is inside this Epoch.
 func (e *Epoch) Contains(t time.Time) bool {
-	return e.Validity.Contains(t)
+	return e.Contains(t)
 }

--- a/go/lib/drkey/epoch.go
+++ b/go/lib/drkey/epoch.go
@@ -1,0 +1,46 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"time"
+
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+// Epoch represents a validity period.
+// TODO use Validity Periods https://github.com/scionproto/scion/pull/2842/files
+type Epoch struct {
+	Begin time.Time
+	End   time.Time
+}
+
+// Equal returns true if both Epochs are identical.
+func (e Epoch) Equal(other Epoch) bool {
+	return e.Begin == other.Begin && e.End == other.End
+}
+
+// NewEpoch constructs an Epoch from its uint32 encoded begin and end parts.
+func NewEpoch(begin, end uint32) Epoch {
+	return Epoch{
+		Begin: util.SecsToTime(begin),
+		End:   util.SecsToTime(end),
+	}
+}
+
+// Contains indicates whether the time point is inside this Epoch.
+func (e *Epoch) Contains(t time.Time) bool {
+	return !e.Begin.After(t) && e.End.After(t)
+}

--- a/go/lib/drkey/exchange/BUILD.bazel
+++ b/go/lib/drkey/exchange/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["suite.go"],
+    importpath = "github.com/scionproto/scion/go/lib/drkey/exchange",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/drkey:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+    ],
+)

--- a/go/lib/drkey/exchange/suite.go
+++ b/go/lib/drkey/exchange/suite.go
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package drkey
+package exchange
 
 import (
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/drkey"
 	"github.com/scionproto/scion/go/lib/scrypto"
 )
 
 // EncryptDRKeyLvl1 does the encryption step in the first level key exchange
-func EncryptDRKeyLvl1(drkey Lvl1Key, nonce, pubkey, privkey common.RawBytes) (common.RawBytes, error) {
+func EncryptDRKeyLvl1(drkey drkey.Lvl1Key, nonce, pubkey, privkey []byte) ([]byte, error) {
 	keyLen := len(drkey.Key)
-	msg := make(common.RawBytes, addr.IABytes*2+keyLen)
+	msg := make([]byte, addr.IABytes*2+keyLen)
 	drkey.SrcIA.Write(msg)
 	drkey.DstIA.Write(msg[addr.IABytes:])
 	copy(msg[addr.IABytes*2:], drkey.Key)
@@ -35,19 +35,19 @@ func EncryptDRKeyLvl1(drkey Lvl1Key, nonce, pubkey, privkey common.RawBytes) (co
 }
 
 // DecryptDRKeyLvl1 decrypts the cipher text received during the first level key exchange
-func DecryptDRKeyLvl1(cipher, nonce, pubkey, privkey common.RawBytes) (Lvl1Key, error) {
+func DecryptDRKeyLvl1(cipher, nonce, pubkey, privkey []byte) (drkey.Lvl1Key, error) {
 	msg, err := scrypto.Decrypt(cipher, nonce, pubkey, privkey, scrypto.Curve25519xSalsa20Poly1305)
 	if err != nil {
-		return Lvl1Key{}, err
+		return drkey.Lvl1Key{}, err
 	}
 	srcIA := addr.IAFromRaw(msg[:addr.IABytes])
 	dstIA := addr.IAFromRaw(msg[addr.IABytes : addr.IABytes*2])
 	key := msg[addr.IABytes*2:]
-	return Lvl1Key{
-		Lvl1Meta: Lvl1Meta{
+	return drkey.Lvl1Key{
+		Lvl1Meta: drkey.Lvl1Meta{
 			SrcIA: srcIA,
 			DstIA: dstIA,
 		},
-		Key: DRKey(key),
+		Key: drkey.DRKey(key),
 	}, nil
 }

--- a/go/lib/drkey/level1.go
+++ b/go/lib/drkey/level1.go
@@ -1,0 +1,44 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"bytes"
+
+	"github.com/scionproto/scion/go/lib/addr"
+)
+
+// Lvl1Meta represents the information about a level 1 DRKey other than the key itself.
+type Lvl1Meta struct {
+	Epoch Epoch
+	SrcIA addr.IA
+	DstIA addr.IA
+}
+
+// Equal returns true if both meta are identical.
+func (m Lvl1Meta) Equal(other Lvl1Meta) bool {
+	return m.Epoch.Equal(other.Epoch) && m.SrcIA.Equal(other.SrcIA) && m.DstIA.Equal(other.DstIA)
+}
+
+// Lvl1Key represents a level 1 DRKey.
+type Lvl1Key struct {
+	Lvl1Meta
+	Key DRKey
+}
+
+// Equal returns true if both level 1 keys are identical.
+func (k Lvl1Key) Equal(other Lvl1Key) bool {
+	return k.Lvl1Meta.Equal(other.Lvl1Meta) && bytes.Compare(k.Key, other.Key) == 0
+}

--- a/go/lib/drkey/level2.go
+++ b/go/lib/drkey/level2.go
@@ -1,0 +1,68 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"bytes"
+
+	"github.com/scionproto/scion/go/lib/addr"
+)
+
+// Lvl2KeyType represents the different types of level 2 DRKeys (AS->AS, AS->host, host->host).
+type Lvl2KeyType uint8
+
+const (
+	AS2AS Lvl2KeyType = iota
+	AS2Host
+	Host2Host
+)
+
+// Lvl2Meta represents the information about a level 2 DRKey, without the key itself.
+type Lvl2Meta struct {
+	KeyType  Lvl2KeyType
+	Protocol string
+	Epoch    Epoch
+	SrcIA    addr.IA
+	DstIA    addr.IA
+	SrcHost  addr.HostAddr
+	DstHost  addr.HostAddr
+}
+
+// Equal returns true if both meta are identical.
+func (m Lvl2Meta) Equal(other Lvl2Meta) bool {
+	return m.KeyType == other.KeyType && m.Protocol == other.Protocol &&
+		m.Epoch.Equal(other.Epoch) && m.SrcIA.Equal(other.SrcIA) && m.DstIA.Equal(other.DstIA) &&
+		m.SrcHost.Equal(other.SrcHost) && m.DstHost.Equal(other.DstHost)
+}
+
+// Lvl2Key represents a level 2 DRKey.
+type Lvl2Key struct {
+	Lvl2Meta
+	Key DRKey
+}
+
+// Equal returns true if both level 2 keys are identical.
+func (k Lvl2Key) Equal(other Lvl2Key) bool {
+	return k.Lvl2Meta.Equal(other.Lvl2Meta) && bytes.Compare(k.Key, other.Key) == 0
+}
+
+// DelegationSecret is similar to a level 2 key, type AS to AS.
+type DelegationSecret struct {
+	Protocol string
+	Epoch    Epoch
+	SrcIA    addr.IA
+	DstIA    addr.IA
+	Key      DRKey
+}

--- a/go/lib/drkey/level2.go
+++ b/go/lib/drkey/level2.go
@@ -23,6 +23,7 @@ import (
 // Lvl2KeyType represents the different types of level 2 DRKeys (AS->AS, AS->host, host->host).
 type Lvl2KeyType uint8
 
+// Lvl2KeyType constants
 const (
 	AS2AS Lvl2KeyType = iota
 	AS2Host

--- a/go/lib/drkey/secret_value.go
+++ b/go/lib/drkey/secret_value.go
@@ -1,0 +1,64 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+
+	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+const drkeySalt = "Derive DRKey Key" // same as in Python
+
+// SVMeta represents the information about a DRKey secret value.
+type SVMeta struct {
+	Epoch Epoch
+}
+
+// SV represents a DRKey secret value.
+type SV struct {
+	SVMeta
+	Key DRKey
+}
+
+// Equal returns true if both secret values are identical.
+func (sv SV) Equal(other SV) bool {
+	return sv.Epoch.Equal(other.Epoch) && bytes.Compare(sv.Key, other.Key) == 0
+}
+
+// DeriveSV constructs a valid SV. asSecret is typically the AS master secret.
+func DeriveSV(meta SVMeta, asSecret common.RawBytes) (SV, error) {
+	msLen := len(asSecret)
+	if msLen == 0 {
+		return SV{}, errors.New("Invalid zero sized secret")
+	}
+	all := make(common.RawBytes, 1+msLen+8)
+	copy(all, []byte{byte(msLen)})
+	copy(all[1:], asSecret)
+	binary.LittleEndian.PutUint32(all[msLen+1:], util.TimeToSecs(meta.Epoch.Begin))
+	binary.LittleEndian.PutUint32(all[msLen+5:], util.TimeToSecs(meta.Epoch.End))
+
+	key := pbkdf2.Key(all, []byte(drkeySalt), 1000, 16, sha256.New)
+	return SV{
+		SVMeta: meta,
+		Key:    DRKey(key),
+	}, nil
+}

--- a/go/lib/drkey/secret_value.go
+++ b/go/lib/drkey/secret_value.go
@@ -22,7 +22,6 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/util"
 )
 
@@ -45,12 +44,12 @@ func (sv SV) Equal(other SV) bool {
 }
 
 // DeriveSV constructs a valid SV. asSecret is typically the AS master secret.
-func DeriveSV(meta SVMeta, asSecret common.RawBytes) (SV, error) {
+func DeriveSV(meta SVMeta, asSecret []byte) (SV, error) {
 	msLen := len(asSecret)
 	if msLen == 0 {
 		return SV{}, errors.New("Invalid zero sized secret")
 	}
-	all := make(common.RawBytes, 1+msLen+8)
+	all := make([]byte, 1+msLen+8)
 	copy(all, []byte{byte(msLen)})
 	copy(all[1:], asSecret)
 	binary.LittleEndian.PutUint32(all[msLen+1:], util.TimeToSecs(meta.Epoch.NotBefore.Time))

--- a/go/lib/drkey/secret_value.go
+++ b/go/lib/drkey/secret_value.go
@@ -53,8 +53,8 @@ func DeriveSV(meta SVMeta, asSecret common.RawBytes) (SV, error) {
 	all := make(common.RawBytes, 1+msLen+8)
 	copy(all, []byte{byte(msLen)})
 	copy(all[1:], asSecret)
-	binary.LittleEndian.PutUint32(all[msLen+1:], util.TimeToSecs(meta.Epoch.Validity.NotBefore.Time))
-	binary.LittleEndian.PutUint32(all[msLen+5:], util.TimeToSecs(meta.Epoch.Validity.NotAfter.Time))
+	binary.LittleEndian.PutUint32(all[msLen+1:], util.TimeToSecs(meta.Epoch.NotBefore.Time))
+	binary.LittleEndian.PutUint32(all[msLen+5:], util.TimeToSecs(meta.Epoch.NotAfter.Time))
 
 	key := pbkdf2.Key(all, []byte(drkeySalt), 1000, 16, sha256.New)
 	return SV{

--- a/go/lib/drkey/secret_value.go
+++ b/go/lib/drkey/secret_value.go
@@ -53,8 +53,8 @@ func DeriveSV(meta SVMeta, asSecret common.RawBytes) (SV, error) {
 	all := make(common.RawBytes, 1+msLen+8)
 	copy(all, []byte{byte(msLen)})
 	copy(all[1:], asSecret)
-	binary.LittleEndian.PutUint32(all[msLen+1:], util.TimeToSecs(meta.Epoch.Begin))
-	binary.LittleEndian.PutUint32(all[msLen+5:], util.TimeToSecs(meta.Epoch.End))
+	binary.LittleEndian.PutUint32(all[msLen+1:], util.TimeToSecs(meta.Epoch.Validity.NotBefore.Time))
+	binary.LittleEndian.PutUint32(all[msLen+5:], util.TimeToSecs(meta.Epoch.Validity.NotAfter.Time))
 
 	key := pbkdf2.Key(all, []byte(drkeySalt), 1000, 16, sha256.New)
 	return SV{

--- a/go/lib/drkey/secret_value_test.go
+++ b/go/lib/drkey/secret_value_test.go
@@ -18,21 +18,21 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 func TestDeriveSV(t *testing.T) {
 	meta := SVMeta{NewEpoch(0, 1)}
-	asSecret := common.RawBytes{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
-	hexKey := "47bfbb7d94706dc9e79825e5a837b006"
+	asSecret := []byte{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
+	targetKey := xtest.MustParseHexString("47bfbb7d94706dc9e79825e5a837b006")
 
 	got, err := DeriveSV(meta, asSecret)
 	if err != nil {
 		t.Errorf("DeriveSV() error = %v", err)
 		return
 	}
-	if hex.EncodeToString(got.Key) != hexKey {
+	if !got.Key.Equal(targetKey) {
 		t.Fatalf("Unexpected sv key: %s, expected: %s",
-			hex.EncodeToString(got.Key), hexKey)
+			hex.EncodeToString(got.Key), hex.EncodeToString(targetKey))
 	}
 }

--- a/go/lib/drkey/secret_value_test.go
+++ b/go/lib/drkey/secret_value_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/common"
+)
+
+func TestDeriveSV(t *testing.T) {
+	meta := SVMeta{NewEpoch(0, 1)}
+	asSecret := common.RawBytes{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
+	hexKey := "47bfbb7d94706dc9e79825e5a837b006"
+
+	got, err := DeriveSV(meta, asSecret)
+	if err != nil {
+		t.Errorf("DeriveSV() error = %v", err)
+		return
+	}
+	if hex.EncodeToString(got.Key) != hexKey {
+		t.Fatalf("Unexpected sv key: %s, expected: %s",
+			hex.EncodeToString(got.Key), hexKey)
+	}
+}

--- a/go/lib/drkey/suite.go
+++ b/go/lib/drkey/suite.go
@@ -1,0 +1,53 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/scrypto"
+)
+
+// EncryptDRKeyLvl1 does the encryption step in the first level key exchange
+func EncryptDRKeyLvl1(drkey Lvl1Key, nonce, pubkey, privkey common.RawBytes) (common.RawBytes, error) {
+	keyLen := len(drkey.Key)
+	msg := make(common.RawBytes, addr.IABytes*2+keyLen)
+	drkey.SrcIA.Write(msg)
+	drkey.DstIA.Write(msg[addr.IABytes:])
+	copy(msg[addr.IABytes*2:], drkey.Key)
+	cipher, err := scrypto.Encrypt(msg, nonce, pubkey, privkey, scrypto.Curve25519xSalsa20Poly1305)
+	if err != nil {
+		return nil, err
+	}
+	return cipher, nil
+}
+
+// DecryptDRKeyLvl1 decrypts the cipher text received during the first level key exchange
+func DecryptDRKeyLvl1(cipher, nonce, pubkey, privkey common.RawBytes) (Lvl1Key, error) {
+	msg, err := scrypto.Decrypt(cipher, nonce, pubkey, privkey, scrypto.Curve25519xSalsa20Poly1305)
+	if err != nil {
+		return Lvl1Key{}, err
+	}
+	srcIA := addr.IAFromRaw(msg[:addr.IABytes])
+	dstIA := addr.IAFromRaw(msg[addr.IABytes : addr.IABytes*2])
+	key := msg[addr.IABytes*2:]
+	return Lvl1Key{
+		Lvl1Meta: Lvl1Meta{
+			SrcIA: srcIA,
+			DstIA: dstIA,
+		},
+		Key: DRKey(key),
+	}, nil
+}


### PR DESCRIPTION
1st PR among several in order to port drkey feature to scionlab. Most of the features were first introduced in https://github.com/netsec-ethz/scion/pull/63.

Next 3 PRs include go/lib/drkey. (1/3)

Some minor changes in this PR:

- Refactoring Epoch based on Validity period https://github.com/scionproto/scion/pull/2842/files.
- Added SV derivation UT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/3)
<!-- Reviewable:end -->
