### PR TITLE
Drkey feature PR2

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -128,7 +128,6 @@ github.com/spf13/cobra v0.0.3-0.20180408161736-cd30c2a7e91a/go.mod h1:1l0Ry5zgKv
 github.com/spf13/pflag v1.0.1-0.20180403115518-1ce0cc6db402 h1:PzXGtoglK0gKAmoFi5ec8tZKKnTTxJM+3i7w/qw+Hf0=
 github.com/spf13/pflag v1.0.1-0.20180403115518-1ce0cc6db402/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/spf13/cobra v0.0.3-0.20180408161736-cd30c2a7e91a/go.mod h1:1l0Ry5zgKv
 github.com/spf13/pflag v1.0.1-0.20180403115518-1ce0cc6db402 h1:PzXGtoglK0gKAmoFi5ec8tZKKnTTxJM+3i7w/qw+Hf0=
 github.com/spf13/pflag v1.0.1-0.20180403115518-1ce0cc6db402/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/go/lib/drkey/exchange/BUILD.bazel
+++ b/go/lib/drkey/exchange/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,5 +9,20 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/drkey:go_default_library",
         "//go/lib/scrypto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["suite_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/drkey:go_default_library",
+        "//go/lib/drkey/protocol:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+        "//go/lib/xtest:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/drkey/exchange/suite_test.go
+++ b/go/lib/drkey/exchange/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 ETH Zurich
+// Copyright 2020 ETH Zurich
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
 package exchange
 
 import (
-	"bytes"
-	"encoding/hex"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/drkey"
@@ -29,39 +30,19 @@ import (
 func TestSuiteDRKeyLvl1(t *testing.T) {
 	lvl1 := genLvl1Key(t)
 	sndPubKey, sndPrivKey, err := scrypto.GenKeyPair(scrypto.Curve25519xSalsa20Poly1305)
-	if err != nil {
-		t.Errorf("GenKeyPair failed = %v", err)
-	}
+	require.NoError(t, err)
 	rcvPubKey, rcvPrivKey, err := scrypto.GenKeyPair(scrypto.Curve25519xSalsa20Poly1305)
-	if err != nil {
-		t.Errorf("GenKeyPair failed = %v", err)
-	}
+	require.NoError(t, err)
 	nonce, err := scrypto.Nonce(24)
-	if err != nil {
-		t.Errorf("Nonce failed = %v", err)
-	}
+	require.NoError(t, err)
 	cipherMsg, err := EncryptDRKeyLvl1(lvl1, nonce, rcvPubKey, sndPrivKey)
-	if err != nil {
-		t.Errorf("EncryptDRKeyLvl1 failed = %v", err)
-	}
+	require.NoError(t, err)
 	gotLvl1, err := DecryptDRKeyLvl1(cipherMsg, nonce, sndPubKey, rcvPrivKey)
-	if err != nil {
-		t.Errorf("DecryptDRKeyLvl1 failed = %v", err)
-	}
+	require.NoError(t, err)
 
-	if !(lvl1.Lvl1Meta.SrcIA.Equal(gotLvl1.Lvl1Meta.SrcIA)) {
-		t.Fatalf("Lvl1 Src IA mismatch %s != %s",
-			lvl1.Lvl1Meta.SrcIA.String(), gotLvl1.Lvl1Meta.SrcIA.String())
-	}
-	if !(lvl1.Lvl1Meta.DstIA.Equal(gotLvl1.Lvl1Meta.DstIA)) {
-		t.Fatalf("Lvl1 Dst IA mismatch %s != %s",
-			lvl1.Lvl1Meta.DstIA.String(), gotLvl1.Lvl1Meta.DstIA.String())
-	}
-	if !lvl1.Key.Equal(gotLvl1.Key) {
-		t.Fatalf("Key mismatch sent: %s, received: %s",
-			hex.EncodeToString(lvl1.Key), hex.EncodeToString(gotLvl1.Key))
-	}
-
+	assert.Equal(t, lvl1.Lvl1Meta.SrcIA, gotLvl1.Lvl1Meta.SrcIA)
+	assert.Equal(t, lvl1.Lvl1Meta.DstIA, gotLvl1.Lvl1Meta.DstIA)
+	assert.Equal(t, lvl1.Key, gotLvl1.Key)
 }
 
 func genLvl1Key(t *testing.T) drkey.Lvl1Key {
@@ -73,26 +54,18 @@ func genLvl1Key(t *testing.T) drkey.Lvl1Key {
 	epoch := drkey.NewEpoch(0, 1)
 	srcIA, _ := addr.IAFromString("1-ff00:0:111")
 	dstIA, _ := addr.IAFromString("1-ff00:0:112")
+
 	sv, err := drkey.DeriveSV(meta, asSecret)
-	if err != nil {
-		t.Errorf("Derive SV failed = %v", err)
-	}
-	if bytes.Compare(sv.Key, svTgtKey) != 0 {
-		t.Fatalf("Unexpected sv key: %s, expected: %s",
-			hex.EncodeToString(sv.Key), hex.EncodeToString(svTgtKey))
-	}
+	require.NoError(t, err)
+	require.Equal(t, []byte(sv.Key), svTgtKey)
 	lvlTgtKey := xtest.MustParseHexString("51663adbc06e55f40a9ad899cf0775e5")
 	lvl1, err := protocol.DeriveLvl1(drkey.Lvl1Meta{
 		Epoch: epoch,
 		SrcIA: srcIA,
 		DstIA: dstIA,
 	}, sv)
-	if err != nil {
-		t.Errorf("DeriveLvl1 failed = %v", err)
-	}
-	if !lvl1.Key.Equal(lvlTgtKey) {
-		t.Fatalf("Unexpected lvl1 key: %s", hex.EncodeToString(lvl1.Key))
-	}
+	require.NoError(t, err)
+	require.Equal(t, []byte(lvl1.Key), lvlTgtKey)
 
 	return lvl1
 }

--- a/go/lib/drkey/exchange/suite_test.go
+++ b/go/lib/drkey/exchange/suite_test.go
@@ -1,0 +1,98 @@
+// Copyright 2018 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exchange
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/drkey/protocol"
+	"github.com/scionproto/scion/go/lib/scrypto"
+	"github.com/scionproto/scion/go/lib/xtest"
+)
+
+func TestSuiteDRKeyLvl1(t *testing.T) {
+	lvl1 := genLvl1Key(t)
+	sndPubKey, sndPrivKey, err := scrypto.GenKeyPair(scrypto.Curve25519xSalsa20Poly1305)
+	if err != nil {
+		t.Errorf("GenKeyPair failed = %v", err)
+	}
+	rcvPubKey, rcvPrivKey, err := scrypto.GenKeyPair(scrypto.Curve25519xSalsa20Poly1305)
+	if err != nil {
+		t.Errorf("GenKeyPair failed = %v", err)
+	}
+	nonce, err := scrypto.Nonce(24)
+	if err != nil {
+		t.Errorf("Nonce failed = %v", err)
+	}
+	cipherMsg, err := EncryptDRKeyLvl1(lvl1, nonce, rcvPubKey, sndPrivKey)
+	if err != nil {
+		t.Errorf("EncryptDRKeyLvl1 failed = %v", err)
+	}
+	gotLvl1, err := DecryptDRKeyLvl1(cipherMsg, nonce, sndPubKey, rcvPrivKey)
+	if err != nil {
+		t.Errorf("DecryptDRKeyLvl1 failed = %v", err)
+	}
+
+	if !(lvl1.Lvl1Meta.SrcIA.Equal(gotLvl1.Lvl1Meta.SrcIA)) {
+		t.Fatalf("Lvl1 Src IA mismatch %s != %s",
+			lvl1.Lvl1Meta.SrcIA.String(), gotLvl1.Lvl1Meta.SrcIA.String())
+	}
+	if !(lvl1.Lvl1Meta.DstIA.Equal(gotLvl1.Lvl1Meta.DstIA)) {
+		t.Fatalf("Lvl1 Dst IA mismatch %s != %s",
+			lvl1.Lvl1Meta.DstIA.String(), gotLvl1.Lvl1Meta.DstIA.String())
+	}
+	if !lvl1.Key.Equal(gotLvl1.Key) {
+		t.Fatalf("Key mismatch sent: %s, received: %s",
+			hex.EncodeToString(lvl1.Key), hex.EncodeToString(gotLvl1.Key))
+	}
+
+}
+
+func genLvl1Key(t *testing.T) drkey.Lvl1Key {
+	meta := drkey.SVMeta{
+		Epoch: drkey.NewEpoch(0, 1),
+	}
+	asSecret := []byte{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
+	svTgtKey := xtest.MustParseHexString("47bfbb7d94706dc9e79825e5a837b006")
+	epoch := drkey.NewEpoch(0, 1)
+	srcIA, _ := addr.IAFromString("1-ff00:0:111")
+	dstIA, _ := addr.IAFromString("1-ff00:0:112")
+	sv, err := drkey.DeriveSV(meta, asSecret)
+	if err != nil {
+		t.Errorf("Derive SV failed = %v", err)
+	}
+	if bytes.Compare(sv.Key, svTgtKey) != 0 {
+		t.Fatalf("Unexpected sv key: %s, expected: %s",
+			hex.EncodeToString(sv.Key), hex.EncodeToString(svTgtKey))
+	}
+	lvlTgtKey := xtest.MustParseHexString("51663adbc06e55f40a9ad899cf0775e5")
+	lvl1, err := protocol.DeriveLvl1(drkey.Lvl1Meta{
+		Epoch: epoch,
+		SrcIA: srcIA,
+		DstIA: dstIA,
+	}, sv)
+	if err != nil {
+		t.Errorf("DeriveLvl1 failed = %v", err)
+	}
+	if !lvl1.Key.Equal(lvlTgtKey) {
+		t.Fatalf("Unexpected lvl1 key: %s", hex.EncodeToString(lvl1.Key))
+	}
+
+	return lvl1
+}

--- a/go/lib/drkey/protocol/BUILD.bazel
+++ b/go/lib/drkey/protocol/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "delegated.go",
+        "piskes.go",
+        "protocol.go",
+        "scmp.go",
+        "standard.go",
+    ],
+    importpath = "github.com/scionproto/scion/go/lib/drkey/protocol",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/drkey:go_default_library",
+        "//go/lib/scrypto:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["protocol_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/drkey:go_default_library",
+    ],
+)

--- a/go/lib/drkey/protocol/BUILD.bazel
+++ b/go/lib/drkey/protocol/BUILD.bazel
@@ -25,7 +25,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/drkey:go_default_library",
         "//go/lib/xtest:go_default_library",
     ],

--- a/go/lib/drkey/protocol/BUILD.bazel
+++ b/go/lib/drkey/protocol/BUILD.bazel
@@ -27,5 +27,7 @@ go_test(
         "//go/lib/addr:go_default_library",
         "//go/lib/drkey:go_default_library",
         "//go/lib/xtest:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/go/lib/drkey/protocol/BUILD.bazel
+++ b/go/lib/drkey/protocol/BUILD.bazel
@@ -27,5 +27,6 @@ go_test(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/drkey:go_default_library",
+        "//go/lib/xtest:go_default_library",
     ],
 )

--- a/go/lib/drkey/protocol/delegated.go
+++ b/go/lib/drkey/protocol/delegated.go
@@ -1,0 +1,99 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"errors"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/scrypto"
+)
+
+// Delegated implements the level 2 drkey derivation from level 1, without DS. It relies on the
+// Standard implementation to derive the DS from the level 1 key.
+type Delegated struct{}
+
+// DeriveLvl2 derives the level 2 DRKey without passing through a delegation secret.
+func (p Delegated) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2Key, error) {
+	metaForDS := meta
+	metaForDS.KeyType = drkey.AS2AS
+	dsKey, err := Standard{}.DeriveLvl2(metaForDS, key)
+	if err != nil {
+		return drkey.Lvl2Key{}, common.NewBasicError("Error deriving DS", err)
+	}
+	ds := drkey.DelegationSecret{
+		Protocol: meta.Protocol,
+		Epoch:    meta.Epoch,
+		SrcIA:    meta.SrcIA,
+		DstIA:    meta.DstIA,
+		Key:      dsKey.Key,
+	}
+	return p.DeriveLvl2FromDS(meta, ds)
+}
+
+// DeriveLvl2FromDS will derive the level 2 key from a delegation secret.
+func (p Delegated) DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecret) (
+	drkey.Lvl2Key, error) {
+
+	h, err := scrypto.InitMac(common.RawBytes(ds.Key))
+	if err != nil {
+		return drkey.Lvl2Key{}, err
+	}
+
+	pLen := 0
+	buffs := []common.RawBytes{}
+	// add to buffs in reverse order:
+	switch meta.KeyType {
+	case drkey.Host2Host:
+		if meta.SrcHost.Size() == 0 {
+			return drkey.Lvl2Key{}, errors.New("Level 2 DRKey requires a src host, but it is empty")
+		}
+		b := meta.SrcHost.Pack()
+		buffs = []common.RawBytes{
+			b,
+			common.RawBytes{byte(len(b))},
+		}
+		pLen += len(b) + 1
+		fallthrough
+	case drkey.AS2Host:
+		if meta.DstHost.Size() == 0 {
+			return drkey.Lvl2Key{}, errors.New("Level 2 DRKey requires a dst host, but it is empty")
+		}
+		b := meta.DstHost.Pack()
+		buffs = append(buffs,
+			b,
+			common.RawBytes{byte(len(b))})
+		pLen += len(b) + 1
+	case drkey.AS2AS:
+		return drkey.Lvl2Key{
+			Lvl2Meta: meta,
+			Key:      ds.Key,
+		}, nil
+	default:
+		return drkey.Lvl2Key{}, common.NewBasicError("Unknown DRKey type", nil)
+	}
+	all := make(common.RawBytes, pLen)
+	pLen = 0
+	for i := len(buffs) - 1; i >= 0; i-- {
+		copy(all[pLen:], buffs[i])
+		pLen += len(buffs[i])
+	}
+	h.Write(all)
+	return drkey.Lvl2Key{
+		Lvl2Meta: meta,
+		Key:      drkey.DRKey(h.Sum(nil)),
+	}, nil
+}

--- a/go/lib/drkey/protocol/delegated.go
+++ b/go/lib/drkey/protocol/delegated.go
@@ -48,13 +48,13 @@ func (p Delegated) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl
 func (p Delegated) DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecret) (
 	drkey.Lvl2Key, error) {
 
-	h, err := scrypto.InitMac(common.RawBytes(ds.Key))
+	h, err := scrypto.InitMac([]byte(ds.Key))
 	if err != nil {
 		return drkey.Lvl2Key{}, err
 	}
 
 	pLen := 0
-	buffs := []common.RawBytes{}
+	buffs := [][]byte{}
 	// add to buffs in reverse order:
 	switch meta.KeyType {
 	case drkey.Host2Host:
@@ -62,9 +62,9 @@ func (p Delegated) DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecr
 			return drkey.Lvl2Key{}, errors.New("Level 2 DRKey requires a src host, but it is empty")
 		}
 		b := meta.SrcHost.Pack()
-		buffs = []common.RawBytes{
+		buffs = [][]byte{
 			b,
-			common.RawBytes{byte(len(b))},
+			[]byte{byte(len(b))},
 		}
 		pLen += len(b) + 1
 		fallthrough
@@ -75,7 +75,7 @@ func (p Delegated) DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecr
 		b := meta.DstHost.Pack()
 		buffs = append(buffs,
 			b,
-			common.RawBytes{byte(len(b))})
+			[]byte{byte(len(b))})
 		pLen += len(b) + 1
 	case drkey.AS2AS:
 		return drkey.Lvl2Key{
@@ -85,7 +85,7 @@ func (p Delegated) DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecr
 	default:
 		return drkey.Lvl2Key{}, common.NewBasicError("Unknown DRKey type", nil)
 	}
-	all := make(common.RawBytes, pLen)
+	all := make([]byte, pLen)
 	pLen = 0
 	for i := len(buffs) - 1; i >= 0; i-- {
 		copy(all[pLen:], buffs[i])

--- a/go/lib/drkey/protocol/piskes.go
+++ b/go/lib/drkey/protocol/piskes.go
@@ -1,0 +1,45 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"github.com/scionproto/scion/go/lib/drkey"
+)
+
+var _ DelegatedDerivation = piskes{}
+
+// piskes implements the derivation for the PISKES protocol.
+type piskes struct{}
+
+// Name returns scmp.
+func (piskes) Name() string {
+	return "piskes"
+}
+
+// DeriveLvl2 uses the standard derivation.
+func (piskes) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2Key, error) {
+	return Delegated{}.DeriveLvl2(meta, key)
+}
+
+func (piskes) DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecret) (
+	drkey.Lvl2Key, error) {
+
+	return Delegated{}.DeriveLvl2FromDS(meta, ds)
+}
+
+func init() {
+	p := piskes{}
+	KnownDerivations[p.Name()] = p
+}

--- a/go/lib/drkey/protocol/protocol.go
+++ b/go/lib/drkey/protocol/protocol.go
@@ -1,0 +1,52 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/scrypto"
+)
+
+// Derivation specifies the interface to implement for a derivation method.
+type Derivation interface {
+	Name() string
+	DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2Key, error)
+}
+
+// DelegatedDerivation extends a Derivation with a derivation from a DS.
+type DelegatedDerivation interface {
+	Derivation
+	DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecret) (drkey.Lvl2Key, error)
+}
+
+// KnownDerivations maps the derivation names to their implementations.
+var KnownDerivations = make(map[string]Derivation)
+
+// DeriveLvl1 constructs a new level 1 DRKey.
+func DeriveLvl1(meta drkey.Lvl1Meta, sv drkey.SV) (drkey.Lvl1Key, error) {
+	mac, err := scrypto.InitMac(common.RawBytes(sv.Key))
+	if err != nil {
+		return drkey.Lvl1Key{}, err
+	}
+	all := make(common.RawBytes, addr.IABytes)
+	meta.DstIA.Write(all)
+	mac.Write(all)
+	return drkey.Lvl1Key{
+		Lvl1Meta: meta,
+		Key:      drkey.DRKey(mac.Sum(nil)),
+	}, nil
+}

--- a/go/lib/drkey/protocol/protocol.go
+++ b/go/lib/drkey/protocol/protocol.go
@@ -16,7 +16,6 @@ package protocol
 
 import (
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/drkey"
 	"github.com/scionproto/scion/go/lib/scrypto"
 )
@@ -38,11 +37,11 @@ var KnownDerivations = make(map[string]Derivation)
 
 // DeriveLvl1 constructs a new level 1 DRKey.
 func DeriveLvl1(meta drkey.Lvl1Meta, sv drkey.SV) (drkey.Lvl1Key, error) {
-	mac, err := scrypto.InitMac(common.RawBytes(sv.Key))
+	mac, err := scrypto.InitMac([]byte(sv.Key))
 	if err != nil {
 		return drkey.Lvl1Key{}, err
 	}
-	all := make(common.RawBytes, addr.IABytes)
+	all := make([]byte, addr.IABytes)
 	meta.DstIA.Write(all)
 	mac.Write(all)
 	return drkey.Lvl1Key{

--- a/go/lib/drkey/protocol/protocol_test.go
+++ b/go/lib/drkey/protocol/protocol_test.go
@@ -1,0 +1,185 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/drkey"
+)
+
+func TestDeriveStandard(t *testing.T) {
+	lvl1 := getLvl1(t)
+	protoToKey := map[string]string{
+		"foo":  "def3aa32ce47d4374469148b5c04fac5",
+		"bar":  "8ada021cabf2b14765f468f3c8995edb",
+		"fooo": "7f8e507aecf38c09e4cb10a0ff0cc497",
+	}
+	for proto, key := range protoToKey {
+		meta := drkey.Lvl2Meta{
+			Protocol: proto,
+			KeyType:  drkey.AS2AS,
+			SrcIA:    lvl1.SrcIA,
+			DstIA:    lvl1.DstIA,
+		}
+		lvl2, err := Standard{}.DeriveLvl2(meta, lvl1)
+		if err != nil {
+			t.Fatalf("Lvl2 failed")
+		}
+		hexKey := hex.EncodeToString(lvl2.Key)
+		if hexKey != key {
+			t.Fatalf("Unexpected lvl2 key for protocol [%s]: %s", proto, hexKey)
+		}
+	}
+	// TODO(juagargi): test as2host and host2host. Get the key values from an authorative source.
+}
+
+func TestDeriveDelegated(t *testing.T) {
+	lvl1 := getLvl1(t)
+	for _, proto := range []string{"foo", "bar", "fooo"} {
+		meta := drkey.Lvl2Meta{
+			Protocol: proto,
+			KeyType:  drkey.AS2AS,
+			SrcIA:    lvl1.SrcIA,
+			DstIA:    lvl1.DstIA,
+		}
+		lvl2standard, err := Delegated{}.DeriveLvl2(meta, lvl1)
+		if err != nil {
+			t.Fatalf("Lvl2 standard failed")
+		}
+		lvl2deleg, err := Delegated{}.DeriveLvl2(meta, lvl1)
+		if err != nil {
+			t.Fatalf("Lvl2 delegated failed")
+		}
+		if !bytes.Equal(lvl2deleg.Key, lvl2standard.Key) {
+			t.Fatalf("Keys must be equal for AS2AS")
+		}
+	}
+	protoToLvl2 := map[string]string{
+		"foo":  "b4279b032d7d81c38754ab7b253f5ac0",
+		"bar":  "a30df8ad348bfce1ecdf1cf83c9e5265",
+		"fooo": "434817fb40cb602b36c80e88789aee46",
+	}
+	for proto, key := range protoToLvl2 {
+		meta := drkey.Lvl2Meta{
+			Protocol: proto,
+			KeyType:  drkey.AS2Host,
+			SrcIA:    lvl1.SrcIA,
+			DstIA:    lvl1.DstIA,
+			DstHost:  addr.HostFromIPStr("127.0.0.1"),
+		}
+		lvl2, err := Delegated{}.DeriveLvl2(meta, lvl1)
+		if err != nil {
+			t.Fatalf("Lvl2 failed")
+		}
+		hexKey := hex.EncodeToString(lvl2.Key)
+		if hexKey != key {
+			t.Fatalf("Unexpected lvl2 key for protocol [%s]: %s", proto, hexKey)
+		}
+	}
+}
+
+func TestDeriveDelegatedViaDS(t *testing.T) {
+	// derive DS and then derive key. Compare to derive directly key
+	lvl1Key := getLvl1(t)
+	meta := drkey.Lvl2Meta{
+		Protocol: "piskes",
+		KeyType:  drkey.AS2AS,
+		SrcIA:    lvl1Key.SrcIA,
+		DstIA:    lvl1Key.DstIA,
+		SrcHost:  addr.HostNone{},
+		DstHost:  addr.HostNone{},
+	}
+	lvl2Key, err := piskes{}.DeriveLvl2(meta, lvl1Key)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	ds := drkey.DelegationSecret{
+		Protocol: lvl2Key.Protocol,
+		Epoch:    lvl2Key.Epoch,
+		SrcIA:    lvl2Key.SrcIA,
+		DstIA:    lvl2Key.DstIA,
+		Key:      lvl2Key.Key,
+	}
+	srcHost := addr.HostFromIPStr("1.1.1.1")
+	dstHost := addr.HostFromIPStr("2.2.2.2")
+	meta = drkey.Lvl2Meta{
+		Protocol: meta.Protocol,
+		KeyType:  drkey.Host2Host,
+		SrcIA:    meta.SrcIA,
+		DstIA:    meta.DstIA,
+		SrcHost:  srcHost,
+		DstHost:  dstHost,
+	}
+	lvl2KeyViaDS, err := piskes{}.DeriveLvl2FromDS(meta, ds)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	_ = lvl2KeyViaDS
+	// now get the level 2 key directly without explicitly going through DS
+	lvl2Key, err = piskes{}.DeriveLvl2(meta, lvl1Key)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !lvl2Key.Equal(lvl2KeyViaDS) {
+		t.Fatalf("Level 2 key from DS and direct should be equal. From DS = %s , direct = %s",
+			hex.EncodeToString(lvl2KeyViaDS.Key), hex.EncodeToString(lvl2Key.Key))
+	}
+}
+
+func getLvl1(t *testing.T) drkey.Lvl1Key {
+	master0 := common.RawBytes{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
+	epoch := drkey.NewEpoch(0, 1)
+	srcIA, _ := addr.IAFromString("1-ff00:0:111")
+	dstIA, _ := addr.IAFromString("1-ff00:0:112")
+	sv, err := drkey.DeriveSV(drkey.SVMeta{
+		Epoch: epoch,
+	}, master0)
+	if err != nil {
+		t.Fatalf("SV failed")
+	}
+	if hex.EncodeToString(sv.Key) != "47bfbb7d94706dc9e79825e5a837b006" {
+		t.Fatalf("Unexpected sv: %s", hex.EncodeToString(sv.Key))
+	}
+	lvl1, err := DeriveLvl1(drkey.Lvl1Meta{
+		Epoch: epoch,
+		SrcIA: srcIA,
+		DstIA: dstIA,
+	}, sv)
+	if err != nil {
+		t.Fatalf("Lvl1 failed")
+	}
+	if hex.EncodeToString(lvl1.Key) != "51663adbc06e55f40a9ad899cf0775e5" {
+		t.Fatalf("Unexpected lvl1 key: %s", hex.EncodeToString(lvl1.Key))
+	}
+	return lvl1
+}
+
+func TestExistingImplementations(t *testing.T) {
+	// we test that we have the four implementations we know for now (standard,deleg,scmp,piskes)
+	if len(KnownDerivations) != 2 {
+		t.Errorf("Wrong number of implementations, expecting 4, got %d", len(KnownDerivations))
+	}
+	if _, found := KnownDerivations["scmp"]; !found {
+		t.Errorf("\"scmp\" implementation not found")
+	}
+	if _, found := KnownDerivations["piskes"]; !found {
+		t.Errorf("\"piskes\" implementation not found")
+	}
+}

--- a/go/lib/drkey/protocol/protocol_test.go
+++ b/go/lib/drkey/protocol/protocol_test.go
@@ -20,8 +20,8 @@ import (
 	"testing"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/xtest"
 )
 
 func TestDeriveStandard(t *testing.T) {
@@ -192,30 +192,35 @@ func TestDeriveDelegatedViaDS(t *testing.T) {
 }
 
 func getLvl1(t *testing.T) drkey.Lvl1Key {
-	master0 := common.RawBytes{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
+	meta := drkey.SVMeta{
+		Epoch: drkey.NewEpoch(0, 1),
+	}
+	asSecret := []byte{0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7}
+	svTgtKey := xtest.MustParseHexString("47bfbb7d94706dc9e79825e5a837b006")
 	epoch := drkey.NewEpoch(0, 1)
 	srcIA, _ := addr.IAFromString("1-ff00:0:111")
 	dstIA, _ := addr.IAFromString("1-ff00:0:112")
-	sv, err := drkey.DeriveSV(drkey.SVMeta{
-		Epoch: epoch,
-	}, master0)
+	sv, err := drkey.DeriveSV(meta, asSecret)
 	if err != nil {
-		t.Fatalf("SV failed")
+		t.Errorf("Derive SV failed = %v", err)
 	}
-	if hex.EncodeToString(sv.Key) != "47bfbb7d94706dc9e79825e5a837b006" {
-		t.Fatalf("Unexpected sv: %s", hex.EncodeToString(sv.Key))
+	if bytes.Compare(sv.Key, svTgtKey) != 0 {
+		t.Fatalf("Unexpected sv key: %s, expected: %s",
+			hex.EncodeToString(sv.Key), hex.EncodeToString(svTgtKey))
 	}
+	lvlTgtKey := xtest.MustParseHexString("51663adbc06e55f40a9ad899cf0775e5")
 	lvl1, err := DeriveLvl1(drkey.Lvl1Meta{
 		Epoch: epoch,
 		SrcIA: srcIA,
 		DstIA: dstIA,
 	}, sv)
 	if err != nil {
-		t.Fatalf("Lvl1 failed")
+		t.Errorf("DeriveLvl1 failed = %v", err)
 	}
-	if hex.EncodeToString(lvl1.Key) != "51663adbc06e55f40a9ad899cf0775e5" {
+	if !lvl1.Key.Equal(lvlTgtKey) {
 		t.Fatalf("Unexpected lvl1 key: %s", hex.EncodeToString(lvl1.Key))
 	}
+
 	return lvl1
 }
 

--- a/go/lib/drkey/protocol/protocol_test.go
+++ b/go/lib/drkey/protocol/protocol_test.go
@@ -47,7 +47,55 @@ func TestDeriveStandard(t *testing.T) {
 			t.Fatalf("Unexpected lvl2 key for protocol [%s]: %s", proto, hexKey)
 		}
 	}
-	// TODO(juagargi): test as2host and host2host. Get the key values from an authorative source.
+
+	dstHost := addr.HostFromIPStr("127.0.0.1")
+	protoToKey = map[string]string{
+		"foo":  "84e628f7c9318d6831ff4f85827f7af3",
+		"bar":  "f51fa0769a6e3d2b9570eefb788a92c0",
+		"fooo": "d88513be2ff73b11615053540146e960",
+	}
+	for proto, key := range protoToKey {
+		meta := drkey.Lvl2Meta{
+			Protocol: proto,
+			KeyType:  drkey.AS2Host,
+			SrcIA:    lvl1.SrcIA,
+			DstIA:    lvl1.DstIA,
+			DstHost:  dstHost,
+		}
+		lvl2, err := Standard{}.DeriveLvl2(meta, lvl1)
+		if err != nil {
+			t.Fatalf("Lvl2 failed")
+		}
+		hexKey := hex.EncodeToString(lvl2.Key)
+		if hexKey != key {
+			t.Fatalf("Unexpected lvl2 AS->Host key for protocol [%s]: %s", proto, hexKey)
+		}
+	}
+
+	srcHost := addr.HostFromIPStr("127.0.0.2")
+	protoToKey = map[string]string{
+		"foo":  "3ca3190844028277e05ebfaf3c2dd3b0",
+		"bar":  "b0bc9ccbd6ca923bdfbad7d1ad358960",
+		"fooo": "5635ad5283cfe080e2c8e99e6c3306af",
+	}
+	for proto, key := range protoToKey {
+		meta := drkey.Lvl2Meta{
+			Protocol: proto,
+			KeyType:  drkey.Host2Host,
+			SrcIA:    lvl1.SrcIA,
+			DstIA:    lvl1.DstIA,
+			SrcHost:  srcHost,
+			DstHost:  dstHost,
+		}
+		lvl2, err := Standard{}.DeriveLvl2(meta, lvl1)
+		if err != nil {
+			t.Fatalf("Lvl2 failed")
+		}
+		hexKey := hex.EncodeToString(lvl2.Key)
+		if hexKey != key {
+			t.Fatalf("Unexpected lvl2 Host->Host key for protocol [%s]: %s", proto, hexKey)
+		}
+	}
 }
 
 func TestDeriveDelegated(t *testing.T) {
@@ -59,7 +107,7 @@ func TestDeriveDelegated(t *testing.T) {
 			SrcIA:    lvl1.SrcIA,
 			DstIA:    lvl1.DstIA,
 		}
-		lvl2standard, err := Delegated{}.DeriveLvl2(meta, lvl1)
+		lvl2standard, err := Standard{}.DeriveLvl2(meta, lvl1)
 		if err != nil {
 			t.Fatalf("Lvl2 standard failed")
 		}
@@ -174,7 +222,7 @@ func getLvl1(t *testing.T) drkey.Lvl1Key {
 func TestExistingImplementations(t *testing.T) {
 	// we test that we have the four implementations we know for now (standard,deleg,scmp,piskes)
 	if len(KnownDerivations) != 2 {
-		t.Errorf("Wrong number of implementations, expecting 4, got %d", len(KnownDerivations))
+		t.Errorf("Wrong number of implementations, expecting 4, got %d", len(KnownDerivations)+2)
 	}
 	if _, found := KnownDerivations["scmp"]; !found {
 		t.Errorf("\"scmp\" implementation not found")

--- a/go/lib/drkey/protocol/protocol_test.go
+++ b/go/lib/drkey/protocol/protocol_test.go
@@ -15,9 +15,10 @@
 package protocol
 
 import (
-	"bytes"
-	"encoding/hex"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/drkey"
@@ -26,11 +27,12 @@ import (
 
 func TestDeriveStandard(t *testing.T) {
 	lvl1 := getLvl1(t)
-	protoToKey := map[string]string{
-		"foo":  "def3aa32ce47d4374469148b5c04fac5",
-		"bar":  "8ada021cabf2b14765f468f3c8995edb",
-		"fooo": "7f8e507aecf38c09e4cb10a0ff0cc497",
+	protoToKey := map[string][]byte{
+		"foo":  xtest.MustParseHexString("def3aa32ce47d4374469148b5c04fac5"),
+		"bar":  xtest.MustParseHexString("8ada021cabf2b14765f468f3c8995edb"),
+		"fooo": xtest.MustParseHexString("7f8e507aecf38c09e4cb10a0ff0cc497"),
 	}
+
 	for proto, key := range protoToKey {
 		meta := drkey.Lvl2Meta{
 			Protocol: proto,
@@ -39,20 +41,15 @@ func TestDeriveStandard(t *testing.T) {
 			DstIA:    lvl1.DstIA,
 		}
 		lvl2, err := Standard{}.DeriveLvl2(meta, lvl1)
-		if err != nil {
-			t.Fatalf("Lvl2 failed")
-		}
-		hexKey := hex.EncodeToString(lvl2.Key)
-		if hexKey != key {
-			t.Fatalf("Unexpected lvl2 key for protocol [%s]: %s", proto, hexKey)
-		}
+		require.NoError(t, err)
+		assert.EqualValues(t, key, lvl2.Key)
 	}
 
 	dstHost := addr.HostFromIPStr("127.0.0.1")
-	protoToKey = map[string]string{
-		"foo":  "84e628f7c9318d6831ff4f85827f7af3",
-		"bar":  "f51fa0769a6e3d2b9570eefb788a92c0",
-		"fooo": "d88513be2ff73b11615053540146e960",
+	protoToKey = map[string][]byte{
+		"foo":  xtest.MustParseHexString("84e628f7c9318d6831ff4f85827f7af3"),
+		"bar":  xtest.MustParseHexString("f51fa0769a6e3d2b9570eefb788a92c0"),
+		"fooo": xtest.MustParseHexString("d88513be2ff73b11615053540146e960"),
 	}
 	for proto, key := range protoToKey {
 		meta := drkey.Lvl2Meta{
@@ -63,20 +60,15 @@ func TestDeriveStandard(t *testing.T) {
 			DstHost:  dstHost,
 		}
 		lvl2, err := Standard{}.DeriveLvl2(meta, lvl1)
-		if err != nil {
-			t.Fatalf("Lvl2 failed")
-		}
-		hexKey := hex.EncodeToString(lvl2.Key)
-		if hexKey != key {
-			t.Fatalf("Unexpected lvl2 AS->Host key for protocol [%s]: %s", proto, hexKey)
-		}
+		require.NoError(t, err)
+		assert.EqualValues(t, key, lvl2.Key)
 	}
 
 	srcHost := addr.HostFromIPStr("127.0.0.2")
-	protoToKey = map[string]string{
-		"foo":  "3ca3190844028277e05ebfaf3c2dd3b0",
-		"bar":  "b0bc9ccbd6ca923bdfbad7d1ad358960",
-		"fooo": "5635ad5283cfe080e2c8e99e6c3306af",
+	protoToKey = map[string][]byte{
+		"foo":  xtest.MustParseHexString("3ca3190844028277e05ebfaf3c2dd3b0"),
+		"bar":  xtest.MustParseHexString("b0bc9ccbd6ca923bdfbad7d1ad358960"),
+		"fooo": xtest.MustParseHexString("5635ad5283cfe080e2c8e99e6c3306af"),
 	}
 	for proto, key := range protoToKey {
 		meta := drkey.Lvl2Meta{
@@ -88,13 +80,8 @@ func TestDeriveStandard(t *testing.T) {
 			DstHost:  dstHost,
 		}
 		lvl2, err := Standard{}.DeriveLvl2(meta, lvl1)
-		if err != nil {
-			t.Fatalf("Lvl2 failed")
-		}
-		hexKey := hex.EncodeToString(lvl2.Key)
-		if hexKey != key {
-			t.Fatalf("Unexpected lvl2 Host->Host key for protocol [%s]: %s", proto, hexKey)
-		}
+		require.NoError(t, err)
+		assert.EqualValues(t, key, lvl2.Key)
 	}
 }
 
@@ -108,21 +95,16 @@ func TestDeriveDelegated(t *testing.T) {
 			DstIA:    lvl1.DstIA,
 		}
 		lvl2standard, err := Standard{}.DeriveLvl2(meta, lvl1)
-		if err != nil {
-			t.Fatalf("Lvl2 standard failed")
-		}
+		require.NoError(t, err)
 		lvl2deleg, err := Delegated{}.DeriveLvl2(meta, lvl1)
-		if err != nil {
-			t.Fatalf("Lvl2 delegated failed")
-		}
-		if !bytes.Equal(lvl2deleg.Key, lvl2standard.Key) {
-			t.Fatalf("Keys must be equal for AS2AS")
-		}
+		require.NoError(t, err)
+		assert.Equal(t, lvl2standard.Key, lvl2deleg.Key)
 	}
-	protoToLvl2 := map[string]string{
-		"foo":  "b4279b032d7d81c38754ab7b253f5ac0",
-		"bar":  "a30df8ad348bfce1ecdf1cf83c9e5265",
-		"fooo": "434817fb40cb602b36c80e88789aee46",
+
+	protoToLvl2 := map[string][]byte{
+		"foo":  xtest.MustParseHexString("b4279b032d7d81c38754ab7b253f5ac0"),
+		"bar":  xtest.MustParseHexString("a30df8ad348bfce1ecdf1cf83c9e5265"),
+		"fooo": xtest.MustParseHexString("434817fb40cb602b36c80e88789aee46"),
 	}
 	for proto, key := range protoToLvl2 {
 		meta := drkey.Lvl2Meta{
@@ -133,13 +115,8 @@ func TestDeriveDelegated(t *testing.T) {
 			DstHost:  addr.HostFromIPStr("127.0.0.1"),
 		}
 		lvl2, err := Delegated{}.DeriveLvl2(meta, lvl1)
-		if err != nil {
-			t.Fatalf("Lvl2 failed")
-		}
-		hexKey := hex.EncodeToString(lvl2.Key)
-		if hexKey != key {
-			t.Fatalf("Unexpected lvl2 key for protocol [%s]: %s", proto, hexKey)
-		}
+		require.NoError(t, err)
+		assert.EqualValues(t, key, lvl2.Key)
 	}
 }
 
@@ -155,9 +132,7 @@ func TestDeriveDelegatedViaDS(t *testing.T) {
 		DstHost:  addr.HostNone{},
 	}
 	lvl2Key, err := piskes{}.DeriveLvl2(meta, lvl1Key)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	ds := drkey.DelegationSecret{
 		Protocol: lvl2Key.Protocol,
 		Epoch:    lvl2Key.Epoch,
@@ -176,19 +151,12 @@ func TestDeriveDelegatedViaDS(t *testing.T) {
 		DstHost:  dstHost,
 	}
 	lvl2KeyViaDS, err := piskes{}.DeriveLvl2FromDS(meta, ds)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	_ = lvl2KeyViaDS
 	// now get the level 2 key directly without explicitly going through DS
 	lvl2Key, err = piskes{}.DeriveLvl2(meta, lvl1Key)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if !lvl2Key.Equal(lvl2KeyViaDS) {
-		t.Fatalf("Level 2 key from DS and direct should be equal. From DS = %s , direct = %s",
-			hex.EncodeToString(lvl2KeyViaDS.Key), hex.EncodeToString(lvl2Key.Key))
-	}
+	require.NoError(t, err)
+	assert.Equal(t, lvl2Key, lvl2KeyViaDS)
 }
 
 func getLvl1(t *testing.T) drkey.Lvl1Key {
@@ -201,38 +169,24 @@ func getLvl1(t *testing.T) drkey.Lvl1Key {
 	srcIA, _ := addr.IAFromString("1-ff00:0:111")
 	dstIA, _ := addr.IAFromString("1-ff00:0:112")
 	sv, err := drkey.DeriveSV(meta, asSecret)
-	if err != nil {
-		t.Errorf("Derive SV failed = %v", err)
-	}
-	if bytes.Compare(sv.Key, svTgtKey) != 0 {
-		t.Fatalf("Unexpected sv key: %s, expected: %s",
-			hex.EncodeToString(sv.Key), hex.EncodeToString(svTgtKey))
-	}
+	require.NoError(t, err)
+	require.EqualValues(t, svTgtKey, sv.Key)
+
 	lvlTgtKey := xtest.MustParseHexString("51663adbc06e55f40a9ad899cf0775e5")
 	lvl1, err := DeriveLvl1(drkey.Lvl1Meta{
 		Epoch: epoch,
 		SrcIA: srcIA,
 		DstIA: dstIA,
 	}, sv)
-	if err != nil {
-		t.Errorf("DeriveLvl1 failed = %v", err)
-	}
-	if !lvl1.Key.Equal(lvlTgtKey) {
-		t.Fatalf("Unexpected lvl1 key: %s", hex.EncodeToString(lvl1.Key))
-	}
+	require.NoError(t, err)
+	require.EqualValues(t, lvlTgtKey, lvl1.Key)
 
 	return lvl1
 }
 
 func TestExistingImplementations(t *testing.T) {
 	// we test that we have the four implementations we know for now (standard,deleg,scmp,piskes)
-	if len(KnownDerivations) != 2 {
-		t.Errorf("Wrong number of implementations, expecting 4, got %d", len(KnownDerivations)+2)
-	}
-	if _, found := KnownDerivations["scmp"]; !found {
-		t.Errorf("\"scmp\" implementation not found")
-	}
-	if _, found := KnownDerivations["piskes"]; !found {
-		t.Errorf("\"piskes\" implementation not found")
-	}
+	require.Len(t, KnownDerivations, 2)
+	require.Contains(t, KnownDerivations, "scmp")
+	require.Contains(t, KnownDerivations, "piskes")
 }

--- a/go/lib/drkey/protocol/scmp.go
+++ b/go/lib/drkey/protocol/scmp.go
@@ -1,0 +1,39 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"github.com/scionproto/scion/go/lib/drkey"
+)
+
+var _ Derivation = scmp{}
+
+// scmp implements the derivation for the SCMP protocol.
+type scmp struct{}
+
+// Name returns scmp.
+func (scmp) Name() string {
+	return "scmp"
+}
+
+// DeriveLvl2 uses the standard derivation.
+func (scmp) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2Key, error) {
+	return Standard{}.DeriveLvl2(meta, key)
+}
+
+func init() {
+	s := scmp{}
+	KnownDerivations[s.Name()] = s
+}

--- a/go/lib/drkey/protocol/standard.go
+++ b/go/lib/drkey/protocol/standard.go
@@ -1,0 +1,87 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import (
+	"errors"
+
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/scrypto"
+)
+
+// TODO(juagargi) the standard derivation (in this file) and delegated one will be just
+// functions: won't implement any interface in particular. The way to configure
+// a new protocol will look like the SCMP or PISKES protocols: new type with their functions, and
+// registration with the correct name. No configuration will be allowed to change this (the
+// configuration file will not include any mapping protocol->derivation).
+
+// Standard implements the level 2 drkey derivation from level 1, without DS.
+type Standard struct{}
+
+// DeriveLvl2 derives the level 2 DRKey without passing through a delegation secret.
+func (p Standard) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2Key, error) {
+	h, err := scrypto.InitMac(common.RawBytes(key.Key))
+	if err != nil {
+		return drkey.Lvl2Key{}, err
+	}
+
+	pLen := 0
+	// add to buffs in reverse order:
+	buffs := []common.RawBytes{}
+	switch meta.KeyType {
+	case drkey.Host2Host:
+		if meta.SrcHost.Size() == 0 {
+			return drkey.Lvl2Key{}, errors.New("Level 2 DRKey requires a src host, but it is empty")
+		}
+		b := meta.SrcHost.Pack()
+		buffs = []common.RawBytes{
+			b,
+			common.RawBytes{byte(len(b))},
+		}
+		pLen += len(b) + 1
+		fallthrough
+	case drkey.AS2Host:
+		if meta.DstHost.Size() == 0 {
+			return drkey.Lvl2Key{}, errors.New("Level 2 DRKey requires a dst host, but it is empty")
+		}
+		b := meta.DstHost.Pack()
+		buffs = append(buffs,
+			b,
+			common.RawBytes{byte(len(b))})
+		pLen += len(b) + 1
+		fallthrough
+	case drkey.AS2AS:
+		b := common.RawBytes(meta.Protocol)
+		buffs = append(buffs,
+			common.RawBytes{byte(meta.KeyType)},
+			b,
+			common.RawBytes{byte(len(b))})
+		pLen += len(b) + 2
+	default:
+		return drkey.Lvl2Key{}, common.NewBasicError("Unknown DRKey type", nil)
+	}
+	all := make(common.RawBytes, pLen)
+	pLen = 0
+	for i := len(buffs) - 1; i >= 0; i-- {
+		copy(all[pLen:], buffs[i])
+		pLen += len(buffs[i])
+	}
+	h.Write(all)
+	return drkey.Lvl2Key{
+		Lvl2Meta: meta,
+		Key:      drkey.DRKey(h.Sum(nil)),
+	}, nil
+}

--- a/go/lib/drkey/protocol/standard.go
+++ b/go/lib/drkey/protocol/standard.go
@@ -33,23 +33,23 @@ type Standard struct{}
 
 // DeriveLvl2 derives the level 2 DRKey without passing through a delegation secret.
 func (p Standard) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2Key, error) {
-	h, err := scrypto.InitMac(common.RawBytes(key.Key))
+	h, err := scrypto.InitMac([]byte(key.Key))
 	if err != nil {
 		return drkey.Lvl2Key{}, err
 	}
 
 	pLen := 0
 	// add to buffs in reverse order:
-	buffs := []common.RawBytes{}
+	buffs := [][]byte{}
 	switch meta.KeyType {
 	case drkey.Host2Host:
 		if meta.SrcHost.Size() == 0 {
 			return drkey.Lvl2Key{}, errors.New("Level 2 DRKey requires a src host, but it is empty")
 		}
 		b := meta.SrcHost.Pack()
-		buffs = []common.RawBytes{
+		buffs = [][]byte{
 			b,
-			common.RawBytes{byte(len(b))},
+			[]byte{byte(len(b))},
 		}
 		pLen += len(b) + 1
 		fallthrough
@@ -60,20 +60,20 @@ func (p Standard) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2
 		b := meta.DstHost.Pack()
 		buffs = append(buffs,
 			b,
-			common.RawBytes{byte(len(b))})
+			[]byte{byte(len(b))})
 		pLen += len(b) + 1
 		fallthrough
 	case drkey.AS2AS:
-		b := common.RawBytes(meta.Protocol)
+		b := []byte(meta.Protocol)
 		buffs = append(buffs,
-			common.RawBytes{byte(meta.KeyType)},
+			[]byte{byte(meta.KeyType)},
 			b,
-			common.RawBytes{byte(len(b))})
+			[]byte{byte(len(b))})
 		pLen += len(b) + 2
 	default:
 		return drkey.Lvl2Key{}, common.NewBasicError("Unknown DRKey type", nil)
 	}
-	all := make(common.RawBytes, pLen)
+	all := make([]byte, pLen)
 	pLen = 0
 	for i := len(buffs) - 1; i >= 0; i-- {
 		copy(all[pLen:], buffs[i])


### PR DESCRIPTION
2nd PR among several in order to port drkey feature to scionlab. Most of the features were first introduced in https://github.com/netsec-ethz/scion/pull/63.

go/lib/drkey. (2/3)

Some changes in this PR:

- Added AS->Host, Host -> Host to the Standard derivation UT.
- Little fixes in other UT (to review).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/4)
<!-- Reviewable:end -->
