### PR TITLE
Do not send notification twice when dropping packet

### DIFF
--- a/go/border/qos/qos.go
+++ b/go/border/qos/qos.go
@@ -214,7 +214,7 @@ func (qosConfig *Configuration) SendNotification(qp *queues.QPkt) {
 
 func (qosConfig *Configuration) dropPacket(qp *queues.QPkt) {
 	defer qp.Rp.Release()
-	qosConfig.SendNotification(qp)
+
 	qosConfig.droppedPackets++
 	log.Info("Dropping packet", "qosConfig.droppedPackets", qosConfig.droppedPackets)
 	var queLen = make([]int, len(*qosConfig.GetQueues()))


### PR DESCRIPTION
This is a bug discovered by Marc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/6)
<!-- Reviewable:end -->
