### PR TITLE
Drkey port pr5

### DIFF
--- a/go/lib/drkeystorage/BUILD.bazel
+++ b/go/lib/drkeystorage/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "sample.go",
+        "store.go",
+    ],
+    importpath = "github.com/scionproto/scion/go/lib/drkeystorage",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/config:go_default_library",
+        "//go/lib/drkey:go_default_library",
+        "//go/lib/drkey/drkeydbsqlite:go_default_library",
+        "//go/lib/drkey/protocol:go_default_library",
+        "//go/lib/infra:go_default_library",
+        "//go/lib/infra/modules/cleaner:go_default_library",
+        "//go/lib/log:go_default_library",
+        "//go/lib/util:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_burntsushi_toml//:go_default_library"],
+)

--- a/go/lib/drkeystorage/BUILD.bazel
+++ b/go/lib/drkeystorage/BUILD.bazel
@@ -27,5 +27,8 @@ go_test(
     name = "go_default_test",
     srcs = ["config_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_burntsushi_toml//:go_default_library"],
+    deps = [
+        "@com_github_burntsushi_toml//:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/go/lib/drkeystorage/config.go
+++ b/go/lib/drkeystorage/config.go
@@ -1,0 +1,240 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkeystorage
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/config"
+	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/drkey/drkeydbsqlite"
+	"github.com/scionproto/scion/go/lib/drkey/protocol"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+// Backend indicates the database backend type.
+type Backend string
+
+const (
+	// backendNone is the empty backend. It defaults to sqlite.
+	backendNone Backend = ""
+	// BackendSqlite indicates an sqlite backend.
+	BackendSqlite Backend = "sqlite"
+)
+
+const (
+	// BackendKey is the backend key in the config mapping.
+	BackendKey = "backend"
+	// ConnectionKey is the connection key in the config mapping.
+	ConnectionKey = "connection"
+	// MaxOpenConnsKey is the key for max open conns in the config mapping.
+	MaxOpenConnsKey = "maxopenconns"
+	// MaxIdleConnsKey is the key for max idle conns in the config mapping.
+	MaxIdleConnsKey = "maxidleconns"
+)
+
+// DRKeyDBConf is the configuration used to describe both a level 1 and 2 DRKey DB.
+type DRKeyDBConf map[string]string
+
+// DelegationList configures which endhosts can get delegation secrets, per protocol.
+type DelegationList map[string][]string
+
+var _ (config.Config) = (*DRKeyDBConf)(nil)
+var _ (config.Config) = (*DelegationList)(nil)
+
+// InitDefaults chooses the sqlite backend if no backend is set and sets all keys to lower case.
+func (cfg *DRKeyDBConf) InitDefaults() {
+	if *cfg == nil {
+		*cfg = make(DRKeyDBConf)
+	}
+	m := *cfg
+	util.LowerKeys(m)
+	if cfg.Backend() == backendNone {
+		m[BackendKey] = string(BackendSqlite)
+	}
+}
+
+// Backend returns the database backend type.
+func (cfg *DRKeyDBConf) Backend() Backend {
+	return Backend((*cfg)[BackendKey])
+}
+
+// Connection returns the database connection information.
+func (cfg *DRKeyDBConf) Connection() string {
+	return (*cfg)[ConnectionKey]
+}
+
+// MaxOpenConns returns the limit for maximum open connections to the database.
+func (cfg *DRKeyDBConf) MaxOpenConns() (int, bool) {
+	val, ok, _ := cfg.parsedInt(MaxOpenConnsKey)
+	return val, ok
+}
+
+// MaxIdleConns returns the limit for maximum idle connections to the database.
+func (cfg *DRKeyDBConf) MaxIdleConns() (int, bool) {
+	val, ok, _ := cfg.parsedInt(MaxIdleConnsKey)
+	return val, ok
+}
+
+func (cfg *DRKeyDBConf) parsedInt(key string) (int, bool, error) {
+	val := (*cfg)[key]
+	if val == "" {
+		return 0, false, nil
+	}
+	i, err := strconv.Atoi(val)
+	return i, true, err
+}
+
+// Validate validates that all values are parsable, and the backend is set.
+func (cfg *DRKeyDBConf) Validate() error {
+	if err := cfg.validateLimits(); err != nil {
+		return err
+	}
+	switch cfg.Backend() {
+	case BackendSqlite:
+		return nil
+	case backendNone:
+		return common.NewBasicError("No backend set", nil)
+	}
+	return common.NewBasicError("Unsupported backend", nil, "backend", cfg.Backend())
+}
+
+func (cfg *DRKeyDBConf) validateLimits() error {
+	if _, _, err := cfg.parsedInt(MaxOpenConnsKey); err != nil {
+		return common.NewBasicError("Invalid MaxOpenConns", nil, "value", (*cfg)[MaxOpenConnsKey])
+	}
+	if _, _, err := cfg.parsedInt(MaxIdleConnsKey); err != nil {
+		return common.NewBasicError("Invalid MaxIdleConns", nil, "value", (*cfg)[MaxIdleConnsKey])
+	}
+	return nil
+}
+
+// Sample writes a config sample to the writer.
+func (cfg *DRKeyDBConf) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {
+	config.WriteString(dst, fmt.Sprintf(drkeyLvl1DBSample, ctx[config.ID]))
+}
+
+// ConfigName is the key in the toml file.
+func (cfg *DRKeyDBConf) ConfigName() string {
+	return "drkeyDB"
+}
+
+// newDB is an internal function that returns a new drkey DB. Call this with a pointer to
+// a function func(string)(drkey.Lvl1DB, error) (also drkey.Lvl2DB) such as
+// drkeydbsqlite.NewLvl1Backend .
+func (cfg *DRKeyDBConf) newDB(newdbFcn func(string) (drkey.BaseDB, error)) (drkey.BaseDB, error) {
+	log.Info("Connecting DRKeyDB", "backend", cfg.Backend(), "connection", cfg.Connection())
+	var err error
+	var db drkey.BaseDB
+	switch cfg.Backend() {
+	case BackendSqlite:
+		db, err = newdbFcn(cfg.Connection())
+	default:
+		return nil, common.NewBasicError("Unsupported backend", nil, "backend", cfg.Backend())
+	}
+	if err != nil {
+		return nil, err
+	}
+	cfg.setConnLimits(db)
+	return db, nil
+}
+
+// NewLvl1DB returns a new level 1 drkey DB.
+func (cfg *DRKeyDBConf) NewLvl1DB() (drkey.Lvl1DB, error) {
+	db, err :=
+		cfg.newDB(func(s string) (drkey.BaseDB, error) { return drkeydbsqlite.NewLvl1Backend(s) })
+	if err != nil {
+		return nil, err
+	}
+	return db.(drkey.Lvl1DB), nil
+}
+
+// NewLvl2DB returns a new level 2 drkey DB.
+func (cfg *DRKeyDBConf) NewLvl2DB() (drkey.Lvl2DB, error) {
+	db, err :=
+		cfg.newDB(func(s string) (drkey.BaseDB, error) { return drkeydbsqlite.NewLvl2Backend(s) })
+	if err != nil {
+		return nil, err
+	}
+	return db.(drkey.Lvl2DB), nil
+}
+
+func (cfg *DRKeyDBConf) setConnLimits(db drkey.BaseDB) {
+	if m, ok := cfg.MaxOpenConns(); ok {
+		db.SetMaxOpenConns(m)
+	}
+	if m, ok := cfg.MaxIdleConns(); ok {
+		db.SetMaxIdleConns(m)
+	}
+}
+
+// InitDefaults will not add or modify any entry in the config.
+func (cfg *DelegationList) InitDefaults() {
+	if *cfg == nil {
+		*cfg = make(DelegationList)
+	}
+}
+
+// Validate validates that the protocols exist, and their addresses are parsable.
+func (cfg *DelegationList) Validate() error {
+	for proto, list := range *cfg {
+		if _, found := protocol.KnownDerivations[proto]; !found {
+			return common.NewBasicError("Configured protocol not found", nil, "protocol", proto)
+		}
+		for _, ip := range list {
+			if h := addr.HostFromIPStr(ip); h == nil {
+				return common.NewBasicError("Syntax error: not a valid address", nil, "ip", ip)
+			}
+		}
+	}
+	return nil
+}
+
+// Sample writes a config sample to the writer.
+func (cfg *DelegationList) Sample(dst io.Writer, path config.Path, ctx config.CtxMap) {
+	config.WriteString(dst, drkeyDelegationListSample)
+}
+
+// ConfigName is the key in the toml file.
+func (cfg *DelegationList) ConfigName() string {
+	return "delegation"
+}
+
+// ToMapPerHost will return map where there is a set of supported protocols per host.
+func (cfg *DelegationList) ToMapPerHost() map[[16]byte]map[string]struct{} {
+	m := make(map[[16]byte]map[string]struct{})
+	for proto, ipList := range *cfg {
+		for _, ip := range ipList {
+			host := addr.HostFromIPStr(ip)
+			if host == nil {
+				continue
+			}
+			var rawHost [16]byte
+			copy(rawHost[:], host.IP().To16())
+			protoSet := m[rawHost]
+			if protoSet == nil {
+				protoSet = make(map[string]struct{})
+			}
+			protoSet[proto] = struct{}{}
+			m[rawHost] = protoSet
+		}
+	}
+	return m
+}

--- a/go/lib/drkeystorage/config_test.go
+++ b/go/lib/drkeystorage/config_test.go
@@ -1,0 +1,158 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkeystorage
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestDelegationListDefaults(t *testing.T) {
+	var cfg DelegationList
+	cfg.InitDefaults()
+	if cfg == nil {
+		t.Errorf("InitDefaults should have initialized the map, but did not")
+	}
+	if len(cfg) != 0 {
+		t.Errorf("InitDefaults should leave the map empty but is not: %+v", cfg)
+	}
+}
+
+func TestDelegationListSyntax(t *testing.T) {
+	var cfg DelegationList
+	sample1 := `piskes = ["1.1.1.1"]`
+	meta, err := toml.Decode(sample1, &cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(meta.Undecoded()) != 0 {
+		t.Fatalf("Should be empty but it's not: %+v", meta.Undecoded())
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Unexpected validation error: %v", err)
+	}
+
+	sample2 := `piskes = ["not an address"]`
+	meta, err = toml.Decode(sample2, &cfg)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(meta.Undecoded()) != 0 {
+		t.Fatalf("Should be empty but it's not: %+v", meta.Undecoded())
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Expected validation error but got none")
+	}
+}
+
+func TestToMapPerHost(t *testing.T) {
+	var cfg DelegationList
+	sample := `piskes = ["1.1.1.1", "2.2.2.2"]
+	scmp = ["1.1.1.1"]`
+	toml.Decode(sample, &cfg)
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Unexpected validation error: %v", err)
+	}
+	m := cfg.ToMapPerHost()
+	if len(m) != 2 {
+		t.Fatalf("The map should contain the two hosts. Map: %v", m)
+	}
+
+	var rawIP [16]byte
+	copy(rawIP[:], net.ParseIP("1.1.1.1").To16())
+	if len(m[rawIP]) != 2 {
+		t.Fatalf("Expecting 2 protocols for 1.1.1.1. Content: %+v", m[rawIP])
+	}
+	if _, found := m[rawIP]["piskes"]; !found {
+		t.Fatalf("Expected to find piskes for 1.1.1.1 but not. Content: %+v", m[rawIP])
+	}
+	if _, found := m[rawIP]["scmp"]; !found {
+		t.Fatalf("Expected to find scmp for 1.1.1.1 but not. Content: %+v", m[rawIP])
+	}
+
+	copy(rawIP[:], net.ParseIP("2.2.2.2").To16())
+	if len(m[rawIP]) != 1 {
+		t.Fatalf("Expecting 1 protocol for 2.2.2.2 ; Content: %+v", m[rawIP])
+	}
+	if _, found := m[rawIP]["piskes"]; !found {
+		t.Fatalf("Expected to find piskes for 2.2.2.2 but not. Content: %+v", m[rawIP])
+	}
+}
+
+func TestInitDRKeyDBDefaults(t *testing.T) {
+	var cfg DRKeyDBConf
+	cfg.InitDefaults()
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if string(cfg.Backend()) != "sqlite" {
+		t.Errorf("Unexpected configuration value: %v", cfg.Backend())
+	}
+	if cfg.Connection() != "" {
+		t.Errorf("Unexpected configuration value: %v", cfg.Connection())
+	}
+}
+
+func TestNewLvl1DB(t *testing.T) {
+	cfg := &DRKeyDBConf{
+		"backend":    "sqlite",
+		"connection": tempFile(t),
+	}
+	db, err := cfg.NewLvl1DB()
+	defer func() {
+		db.Close()
+		os.Remove(cfg.Connection())
+	}()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if db == nil {
+		t.Fatal("Returned DB is nil")
+	}
+}
+
+func TestNewLvl2DB(t *testing.T) {
+	cfg := &DRKeyDBConf{
+		"backend":    "sqlite",
+		"connection": tempFile(t),
+	}
+	db, err := cfg.NewLvl2DB()
+	defer func() {
+		db.Close()
+		os.Remove(cfg.Connection())
+	}()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if db == nil {
+		t.Fatal("Returned DB is nil")
+	}
+}
+
+func tempFile(t *testing.T) string {
+	file, err := ioutil.TempFile("", "db-test-")
+	if err != nil {
+		t.Fatalf("unable to create temp file")
+	}
+	name := file.Name()
+	if err := file.Close(); err != nil {
+		t.Fatalf("unable to close temp file")
+	}
+	return name
+}

--- a/go/lib/drkeystorage/config_test.go
+++ b/go/lib/drkeystorage/config_test.go
@@ -21,44 +21,29 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDelegationListDefaults(t *testing.T) {
 	var cfg DelegationList
 	cfg.InitDefaults()
-	if cfg == nil {
-		t.Errorf("InitDefaults should have initialized the map, but did not")
-	}
-	if len(cfg) != 0 {
-		t.Errorf("InitDefaults should leave the map empty but is not: %+v", cfg)
-	}
+	require.NotNil(t, cfg)
+	require.Empty(t, cfg)
 }
 
 func TestDelegationListSyntax(t *testing.T) {
 	var cfg DelegationList
 	sample1 := `piskes = ["1.1.1.1"]`
 	meta, err := toml.Decode(sample1, &cfg)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if len(meta.Undecoded()) != 0 {
-		t.Fatalf("Should be empty but it's not: %+v", meta.Undecoded())
-	}
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("Unexpected validation error: %v", err)
-	}
+	require.NoError(t, err)
+	require.Empty(t, meta.Undecoded())
+	require.NoError(t, cfg.Validate())
 
 	sample2 := `piskes = ["not an address"]`
 	meta, err = toml.Decode(sample2, &cfg)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if len(meta.Undecoded()) != 0 {
-		t.Fatalf("Should be empty but it's not: %+v", meta.Undecoded())
-	}
-	if err := cfg.Validate(); err == nil {
-		t.Fatalf("Expected validation error but got none")
-	}
+	require.NoError(t, err)
+	require.Empty(t, meta.Undecoded())
+	require.Error(t, cfg.Validate())
 }
 
 func TestToMapPerHost(t *testing.T) {
@@ -66,47 +51,27 @@ func TestToMapPerHost(t *testing.T) {
 	sample := `piskes = ["1.1.1.1", "2.2.2.2"]
 	scmp = ["1.1.1.1"]`
 	toml.Decode(sample, &cfg)
-	if err := cfg.Validate(); err != nil {
-		t.Fatalf("Unexpected validation error: %v", err)
-	}
+	require.NoError(t, cfg.Validate())
 	m := cfg.ToMapPerHost()
-	if len(m) != 2 {
-		t.Fatalf("The map should contain the two hosts. Map: %v", m)
-	}
+	require.Len(t, m, 2)
 
 	var rawIP [16]byte
 	copy(rawIP[:], net.ParseIP("1.1.1.1").To16())
-	if len(m[rawIP]) != 2 {
-		t.Fatalf("Expecting 2 protocols for 1.1.1.1. Content: %+v", m[rawIP])
-	}
-	if _, found := m[rawIP]["piskes"]; !found {
-		t.Fatalf("Expected to find piskes for 1.1.1.1 but not. Content: %+v", m[rawIP])
-	}
-	if _, found := m[rawIP]["scmp"]; !found {
-		t.Fatalf("Expected to find scmp for 1.1.1.1 but not. Content: %+v", m[rawIP])
-	}
+	require.Len(t, m[rawIP], 2)
+	require.Contains(t, m[rawIP], "piskes")
+	require.Contains(t, m[rawIP], "scmp")
 
 	copy(rawIP[:], net.ParseIP("2.2.2.2").To16())
-	if len(m[rawIP]) != 1 {
-		t.Fatalf("Expecting 1 protocol for 2.2.2.2 ; Content: %+v", m[rawIP])
-	}
-	if _, found := m[rawIP]["piskes"]; !found {
-		t.Fatalf("Expected to find piskes for 2.2.2.2 but not. Content: %+v", m[rawIP])
-	}
+	require.Len(t, m[rawIP], 1)
+	require.Contains(t, m[rawIP], "piskes")
 }
 
 func TestInitDRKeyDBDefaults(t *testing.T) {
 	var cfg DRKeyDBConf
 	cfg.InitDefaults()
-	if err := cfg.Validate(); err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-	if string(cfg.Backend()) != "sqlite" {
-		t.Errorf("Unexpected configuration value: %v", cfg.Backend())
-	}
-	if cfg.Connection() != "" {
-		t.Errorf("Unexpected configuration value: %v", cfg.Connection())
-	}
+	require.NoError(t, cfg.Validate())
+	require.EqualValues(t, "sqlite", cfg.Backend())
+	require.Empty(t, cfg.Connection())
 }
 
 func TestNewLvl1DB(t *testing.T) {
@@ -119,12 +84,8 @@ func TestNewLvl1DB(t *testing.T) {
 		db.Close()
 		os.Remove(cfg.Connection())
 	}()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if db == nil {
-		t.Fatal("Returned DB is nil")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, db)
 }
 
 func TestNewLvl2DB(t *testing.T) {
@@ -137,22 +98,15 @@ func TestNewLvl2DB(t *testing.T) {
 		db.Close()
 		os.Remove(cfg.Connection())
 	}()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if db == nil {
-		t.Fatal("Returned DB is nil")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, db)
 }
 
 func tempFile(t *testing.T) string {
 	file, err := ioutil.TempFile("", "db-test-")
-	if err != nil {
-		t.Fatalf("unable to create temp file")
-	}
+	require.NoError(t, err)
 	name := file.Name()
-	if err := file.Close(); err != nil {
-		t.Fatalf("unable to close temp file")
-	}
+	err = file.Close()
+	require.NoError(t, err)
 	return name
 }

--- a/go/lib/drkeystorage/sample.go
+++ b/go/lib/drkeystorage/sample.go
@@ -1,0 +1,36 @@
+// Copyright 2019 ETH Zurich, Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkeystorage
+
+const drkeyLvl1DBSample = `
+# The type of drkeydb backend. (default sqlite)
+Backend = "sqlite"
+
+# Connection for the drkey database.
+Connection = "/var/lib/scion/drkeydb/%s.drkey.db"
+
+# The maximum number of open connections to the database. In case of the
+# empty string, the limit is not set and uses the go default. (default "")
+MaxOpenConns = ""
+
+# The maximum number of idle connections to the database. In case of the
+# empty string, the limit is not set and uses the go default. (default "")
+MaxIdleConns = ""
+`
+
+const drkeyDelegationListSample = `
+# The list of hosts authorized to get a DS per protocol.
+piskes = [ "127.0.0.1", "127.0.0.2"]
+`

--- a/go/lib/drkeystorage/store.go
+++ b/go/lib/drkeystorage/store.go
@@ -1,0 +1,62 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkeystorage
+
+import (
+	"context"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/infra"
+	"github.com/scionproto/scion/go/lib/infra/modules/cleaner"
+)
+
+// SecretValueFactory has the functionality to store secret values.
+type SecretValueFactory interface {
+	GetSecretValue(time.Time) (drkey.SV, error)
+}
+
+// BaseStore is the common base for any drkey store.
+type BaseStore interface {
+	DeleteExpiredKeys(ctx context.Context) (int, error)
+}
+
+// ServiceStore is the level 1 drkey store, used by the CS.
+// It will keep a cache of those keys that were retrieved from the network.
+// It automatically removes expired keys.
+type ServiceStore interface {
+	BaseStore
+	SetMessenger(msger infra.Messenger)
+	GetLvl1Key(ctx context.Context, meta drkey.Lvl1Meta, valTime time.Time) (drkey.Lvl1Key, error)
+	NewLvl1ReqHandler() infra.Handler
+	NewLvl2ReqHandler() infra.Handler
+	KnownASes(ctx context.Context) ([]addr.IA, error)
+}
+
+// ClientStore is the level 2 drkey store, used by sciond.
+// It can get level 2 keys from its backes storage, or by
+// asking a remote CS.
+type ClientStore interface {
+	BaseStore
+	GetLvl2Key(ctx context.Context, meta drkey.Lvl2Meta, valTime time.Time) (drkey.Lvl2Key, error)
+}
+
+// NewStoreCleaner creates a Cleaner task that removes expired level 1 drkeys.
+func NewStoreCleaner(s BaseStore) *cleaner.Cleaner {
+	return cleaner.New(func(ctx context.Context) (int, error) {
+		return s.DeleteExpiredKeys(ctx)
+	}, "drkey")
+}


### PR DESCRIPTION
5th PR among several in order to port drkey feature to scionlab. Most of the features were first introduced in netsec-ethz#63.

Drkey feature in go/lib/drkeystorage.

Some minor changes:
- Test refactoring using testify

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/11)
<!-- Reviewable:end -->
