### PR TITLE
Drkey port pr6

### DIFF
--- a/go/lib/infra/BUILD.bazel
+++ b/go/lib/infra/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//go/lib/ctrl:go_default_library",
         "//go/lib/ctrl/ack:go_default_library",
         "//go/lib/ctrl/cert_mgmt:go_default_library",
+        "//go/lib/ctrl/drkey_mgmt:go_default_library",
         "//go/lib/ctrl/ifid:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",

--- a/go/lib/infra/common.go
+++ b/go/lib/infra/common.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/ack"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/ifid"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
@@ -152,6 +153,10 @@ const (
 	HPSegReply
 	HPCfgRequest
 	HPCfgReply
+	DRKeyLvl1Request
+	DRKeyLvl1Reply
+	DRKeyLvl2Request
+	DRKeyLvl2Reply
 )
 
 func (mt MessageType) String() string {
@@ -208,6 +213,14 @@ func (mt MessageType) String() string {
 		return "HPCfgRequest"
 	case HPCfgReply:
 		return "HPCfgReply"
+	case DRKeyLvl1Request:
+		return "DRKeyLvl1Request"
+	case DRKeyLvl1Reply:
+		return "DRKeyLvl1Reply"
+	case DRKeyLvl2Request:
+		return "DRKeyLvl2Request"
+	case DRKeyLvl2Reply:
+		return "DRKeyLvl2Reply"
 	default:
 		return fmt.Sprintf("Unknown (%d)", mt)
 	}
@@ -269,6 +282,14 @@ func (mt MessageType) MetricLabel() string {
 		return "hp_cfg_req"
 	case HPCfgReply:
 		return "hp_cfg_push"
+	case DRKeyLvl1Request:
+		return "drkey_lvl1_req"
+	case DRKeyLvl1Reply:
+		return "drkey_lvl1_push"
+	case DRKeyLvl2Request:
+		return "drkey_lvl2_req"
+	case DRKeyLvl2Reply:
+		return "drkey_lvl2_push"
 	default:
 		return "unknown_mt"
 	}
@@ -361,6 +382,15 @@ type Messenger interface {
 	SendChainIssueReply(ctx context.Context, msg *cert_mgmt.ChainIssRep, a net.Addr,
 		id uint64) error
 	SendBeacon(ctx context.Context, msg *seg.Beacon, a net.Addr, id uint64) error
+	// TODO(juagargi) rename these functions:
+	GetDRKeyLvl1(ctx context.Context, msg *drkey_mgmt.Lvl1Req, a net.Addr,
+		id uint64) (*drkey_mgmt.Lvl1Rep, error)
+	SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1Rep, a net.Addr,
+		id uint64) error
+	GetDRKeyLvl2(ctx context.Context, msg *drkey_mgmt.Lvl2Req, a net.Addr,
+		id uint64) (*drkey_mgmt.Lvl2Rep, error)
+	SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2Rep, a net.Addr,
+		id uint64) error
 	UpdateSigner(signer Signer, types []MessageType)
 	UpdateVerifier(verifier Verifier)
 	AddHandler(msgType MessageType, h Handler)
@@ -377,6 +407,8 @@ type ResponseWriter interface {
 	SendIfStateInfoReply(ctx context.Context, msg *path_mgmt.IFStateInfos) error
 	SendHPSegReply(ctx context.Context, msg *path_mgmt.HPSegReply) error
 	SendHPCfgReply(ctx context.Context, msg *path_mgmt.HPCfgReply) error
+	SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1Rep) error
+	SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2Rep) error
 }
 
 func ResponseWriterFromContext(ctx context.Context) (ResponseWriter, bool) {

--- a/go/lib/infra/messenger/BUILD.bazel
+++ b/go/lib/infra/messenger/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//go/lib/ctrl/ack:go_default_library",
         "//go/lib/ctrl/cert_mgmt:go_default_library",
         "//go/lib/ctrl/ctrl_msg:go_default_library",
+        "//go/lib/ctrl/drkey_mgmt:go_default_library",
         "//go/lib/ctrl/ifid:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -39,6 +39,10 @@
 //  infra.HPCfgReply          -> ctrl.SignedPld/ctrl.Pld/path_mgmt.HPCfgReply
 //  infra.ChainIssueRequest   -> ctrl.SignedPld/ctrl.Pld/cert_mgmt.ChainIssReq
 //  infra.ChainIssueReply     -> ctrl.SignedPld/ctrl.Pld/cert_mgmt.ChainIssRep
+//	infra.DRKeyLvl1Request    -> ctrl.SignedPld/ctrl.Pld/drkey_mgmt.Lvl1Req
+//	infra.DRKeyLvl1Reply      -> ctrl.SignedPld/ctrl.Pld/drkey_mgmt.Lvl1Rep
+//	infra.DRKeyLvl2Request    -> ctrl.SignedPld/ctrl.Pld/drkey_mgmt.Lvl2Req
+//	infra.DRKeyLvl2Reply      -> ctrl.SignedPld/ctrl.Pld/drkey_mgmt.Lvl2Rep
 //
 // To start processing messages received via the Messenger, call
 // ListenAndServe. The method runs in the current goroutine, and spawns new
@@ -92,6 +96,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl/ack"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/ctrl_msg"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/ifid"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/seg"
@@ -697,6 +702,86 @@ func (m *Messenger) SendBeacon(ctx context.Context, msg *seg.Beacon, a net.Addr,
 	}
 }
 
+func (m *Messenger) GetDRKeyLvl1(ctx context.Context, msg *drkey_mgmt.Lvl1Req, a net.Addr,
+	id uint64) (*drkey_mgmt.Lvl1Rep, error) {
+
+	logger := log.FromCtx(ctx)
+	pld, err := ctrl.NewDRKeyMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("[Messenger] Sending request", "req_type", infra.DRKeyLvl1Request,
+		"msg_id", id, "request", msg, "peer", a)
+	replyCtrlPld, err :=
+		m.getFallbackRequester(infra.DRKeyLvl1Request).Request(ctx, pld, a, false)
+	if err != nil {
+		return nil, common.NewBasicError("[Messenger] Request error", err, "req_type", infra.DRKeyLvl1Request)
+	}
+	_, replyMsg, err := Validate(replyCtrlPld)
+	if err != nil {
+		return nil, common.NewBasicError("[Messenger] Reply validation failed", err)
+	}
+	reply, ok := replyMsg.(*drkey_mgmt.Lvl1Rep)
+	if !ok {
+		err := newTypeAssertErr("*drkey_mgmt.Lvl1Rep", replyMsg)
+		return nil, common.NewBasicError("[Messenger] Type assertion failed", err)
+	}
+	logger.Debug("[Messenger] Received reply")
+	return reply, nil
+}
+
+func (m *Messenger) SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1Rep, a net.Addr,
+	id uint64) error {
+
+	pld, err := ctrl.NewDRKeyMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
+	if err != nil {
+		return err
+	}
+	logger := log.FromCtx(ctx)
+	logger.Debug("[Messenger] Sending Notify", "type", infra.DRKeyLvl1Request, "to", a, "id", id)
+	return m.getFallbackRequester(infra.DRKeyLvl1Request).Notify(ctx, pld, a)
+}
+
+func (m *Messenger) GetDRKeyLvl2(ctx context.Context, msg *drkey_mgmt.Lvl2Req, a net.Addr,
+	id uint64) (*drkey_mgmt.Lvl2Rep, error) {
+
+	logger := log.FromCtx(ctx)
+	pld, err := ctrl.NewDRKeyMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("[Messenger] Sending request", "req_type", infra.DRKeyLvl2Request,
+		"msg_id", id, "request", msg, "peer", a)
+	replyCtrlPld, err :=
+		m.getFallbackRequester(infra.DRKeyLvl2Request).Request(ctx, pld, a, false)
+	if err != nil {
+		return nil, common.NewBasicError("[Messenger] Request error", err, "req_type", infra.DRKeyLvl2Request)
+	}
+	_, replyMsg, err := Validate(replyCtrlPld)
+	if err != nil {
+		return nil, common.NewBasicError("[Messenger] Reply validation failed", err)
+	}
+	reply, ok := replyMsg.(*drkey_mgmt.Lvl2Rep)
+	if !ok {
+		err := newTypeAssertErr("*drkey_mgmt.Lvl2Rep", replyMsg)
+		return nil, common.NewBasicError("[Messenger] Type assertion failed", err)
+	}
+	logger.Debug("[Messenger] Received reply")
+	return reply, nil
+}
+
+func (m *Messenger) SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2Rep, a net.Addr,
+	id uint64) error {
+
+	pld, err := ctrl.NewDRKeyMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
+	if err != nil {
+		return err
+	}
+	logger := log.FromCtx(ctx)
+	logger.Debug("[Messenger] Sending Notify", "type", infra.DRKeyLvl2Request, "to", a, "id", id)
+	return m.getFallbackRequester(infra.DRKeyLvl2Request).Notify(ctx, pld, a)
+}
+
 // sendMessage sends payload msg of type expectedType to address a, using id.
 // If waiting for Acks is disabled, sendMessage returns immediately after
 // sending the message on the network. If waiting for Acks is enabled,
@@ -1128,6 +1213,21 @@ func Validate(pld *ctrl.Pld) (infra.MessageType, proto.Cerealizable, error) {
 		}
 	case proto.CtrlPld_Which_ack:
 		return infra.Ack, pld.Ack, nil
+	case proto.CtrlPld_Which_drkeyMgmt:
+		switch pld.DRKeyMgmt.Which {
+		case proto.DRKeyMgmt_Which_drkeyLvl1Req:
+			return infra.DRKeyLvl1Request, pld.DRKeyMgmt.Lvl1Req, nil
+		case proto.DRKeyMgmt_Which_drkeyLvl1Rep:
+			return infra.DRKeyLvl1Reply, pld.DRKeyMgmt.Lvl1Rep, nil
+		case proto.DRKeyMgmt_Which_drkeyLvl2Req:
+			return infra.DRKeyLvl2Request, pld.DRKeyMgmt.Lvl2Req, nil
+		case proto.DRKeyMgmt_Which_drkeyLvl2Rep:
+			return infra.DRKeyLvl2Reply, pld.DRKeyMgmt.Lvl2Rep, nil
+		default:
+			return infra.None, nil,
+				common.NewBasicError("Unsupported SignedPld.CtrlPld.DRKeyMgmt.Xxx message type",
+					nil, "capnp_which", pld.DRKeyMgmt.Which)
+		}
 	default:
 		return infra.None, nil, common.NewBasicError("Unsupported SignedPld.Pld.Xxx message type",
 			nil, "capnp_which", pld.Which)

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -738,8 +738,8 @@ func (m *Messenger) SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1
 		return err
 	}
 	logger := log.FromCtx(ctx)
-	logger.Debug("[Messenger] Sending Notify", "type", infra.DRKeyLvl1Request, "to", a, "id", id)
-	return m.getFallbackRequester(infra.DRKeyLvl1Request).Notify(ctx, pld, a)
+	logger.Debug("[Messenger] Sending Notify", "type", infra.DRKeyLvl1Reply, "to", a, "id", id)
+	return m.getFallbackRequester(infra.DRKeyLvl1Reply).Notify(ctx, pld, a)
 }
 
 func (m *Messenger) GetDRKeyLvl2(ctx context.Context, msg *drkey_mgmt.Lvl2Req, a net.Addr,
@@ -778,8 +778,8 @@ func (m *Messenger) SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2
 		return err
 	}
 	logger := log.FromCtx(ctx)
-	logger.Debug("[Messenger] Sending Notify", "type", infra.DRKeyLvl2Request, "to", a, "id", id)
-	return m.getFallbackRequester(infra.DRKeyLvl2Request).Notify(ctx, pld, a)
+	logger.Debug("[Messenger] Sending Notify", "type", infra.DRKeyLvl2Reply, "to", a, "id", id)
+	return m.getFallbackRequester(infra.DRKeyLvl2Reply).Notify(ctx, pld, a)
 }
 
 // sendMessage sends payload msg of type expectedType to address a, using id.

--- a/go/lib/infra/messenger/quic_response_writer.go
+++ b/go/lib/infra/messenger/quic_response_writer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/ack"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/rpc"
@@ -129,6 +130,32 @@ func (rw *QUICResponseWriter) SendHPCfgReply(ctx context.Context, msg *path_mgmt
 		rw.ReplyWriter.Close()
 	}()
 	ctrlPld, err := ctrl.NewPathMgmtPld(msg, nil, &ctrl.Data{ReqId: rw.ID})
+	if err != nil {
+		return err
+	}
+	return rw.sendMessage(ctrlPld)
+}
+
+func (rw *QUICResponseWriter) SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1Rep) error {
+	go func() {
+		defer log.HandlePanic()
+		<-ctx.Done()
+		rw.ReplyWriter.Close()
+	}()
+	ctrlPld, err := ctrl.NewDRKeyMgmtPld(msg, nil, &ctrl.Data{ReqId: rw.ID})
+	if err != nil {
+		return err
+	}
+	return rw.sendMessage(ctrlPld)
+}
+
+func (rw *QUICResponseWriter) SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2Rep) error {
+	go func() {
+		defer log.HandlePanic()
+		<-ctx.Done()
+		rw.ReplyWriter.Close()
+	}()
+	ctrlPld, err := ctrl.NewDRKeyMgmtPld(msg, nil, &ctrl.Data{ReqId: rw.ID})
 	if err != nil {
 		return err
 	}

--- a/go/lib/infra/messenger/udp_response_writer.go
+++ b/go/lib/infra/messenger/udp_response_writer.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/ctrl/ack"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 )
@@ -66,4 +67,11 @@ func (rw *UDPResponseWriter) SendHPSegReply(ctx context.Context, msg *path_mgmt.
 
 func (rw *UDPResponseWriter) SendHPCfgReply(ctx context.Context, msg *path_mgmt.HPCfgReply) error {
 	return rw.Messenger.SendHPCfgReply(ctx, msg, rw.Remote, rw.ID)
+}
+
+func (rw *UDPResponseWriter) SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1Rep) error {
+	return rw.Messenger.SendDRKeyLvl1Reply(ctx, msg, rw.Remote, rw.ID)
+}
+func (rw *UDPResponseWriter) SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2Rep) error {
+	return rw.Messenger.SendDRKeyLvl2Reply(ctx, msg, rw.Remote, rw.ID)
 }

--- a/go/lib/infra/mock_infra/BUILD.bazel
+++ b/go/lib/infra/mock_infra/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//go/lib/ctrl:go_default_library",
         "//go/lib/ctrl/ack:go_default_library",
         "//go/lib/ctrl/cert_mgmt:go_default_library",
+        "//go/lib/ctrl/drkey_mgmt:go_default_library",
         "//go/lib/ctrl/ifid:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/ctrl/seg:go_default_library",

--- a/go/lib/infra/mock_infra/infra.go
+++ b/go/lib/infra/mock_infra/infra.go
@@ -12,6 +12,7 @@ import (
 	ctrl "github.com/scionproto/scion/go/lib/ctrl"
 	ack "github.com/scionproto/scion/go/lib/ctrl/ack"
 	cert_mgmt "github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	drkey_mgmt "github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	ifid "github.com/scionproto/scion/go/lib/ctrl/ifid"
 	path_mgmt "github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	seg "github.com/scionproto/scion/go/lib/ctrl/seg"
@@ -136,6 +137,36 @@ func (m *MockMessenger) GetCertChain(arg0 context.Context, arg1 *cert_mgmt.Chain
 func (mr *MockMessengerMockRecorder) GetCertChain(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCertChain", reflect.TypeOf((*MockMessenger)(nil).GetCertChain), arg0, arg1, arg2, arg3)
+}
+
+// GetDRKeyLvl1 mocks base method
+func (m *MockMessenger) GetDRKeyLvl1(arg0 context.Context, arg1 *drkey_mgmt.Lvl1Req, arg2 net.Addr, arg3 uint64) (*drkey_mgmt.Lvl1Rep, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDRKeyLvl1", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*drkey_mgmt.Lvl1Rep)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDRKeyLvl1 indicates an expected call of GetDRKeyLvl1
+func (mr *MockMessengerMockRecorder) GetDRKeyLvl1(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDRKeyLvl1", reflect.TypeOf((*MockMessenger)(nil).GetDRKeyLvl1), arg0, arg1, arg2, arg3)
+}
+
+// GetDRKeyLvl2 mocks base method
+func (m *MockMessenger) GetDRKeyLvl2(arg0 context.Context, arg1 *drkey_mgmt.Lvl2Req, arg2 net.Addr, arg3 uint64) (*drkey_mgmt.Lvl2Rep, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDRKeyLvl2", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*drkey_mgmt.Lvl2Rep)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDRKeyLvl2 indicates an expected call of GetDRKeyLvl2
+func (mr *MockMessengerMockRecorder) GetDRKeyLvl2(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDRKeyLvl2", reflect.TypeOf((*MockMessenger)(nil).GetDRKeyLvl2), arg0, arg1, arg2, arg3)
 }
 
 // GetHPCfgs mocks base method
@@ -309,6 +340,34 @@ func (m *MockMessenger) SendChainIssueReply(arg0 context.Context, arg1 *cert_mgm
 func (mr *MockMessengerMockRecorder) SendChainIssueReply(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendChainIssueReply", reflect.TypeOf((*MockMessenger)(nil).SendChainIssueReply), arg0, arg1, arg2, arg3)
+}
+
+// SendDRKeyLvl1Reply mocks base method
+func (m *MockMessenger) SendDRKeyLvl1Reply(arg0 context.Context, arg1 *drkey_mgmt.Lvl1Rep, arg2 net.Addr, arg3 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendDRKeyLvl1Reply", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendDRKeyLvl1Reply indicates an expected call of SendDRKeyLvl1Reply
+func (mr *MockMessengerMockRecorder) SendDRKeyLvl1Reply(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDRKeyLvl1Reply", reflect.TypeOf((*MockMessenger)(nil).SendDRKeyLvl1Reply), arg0, arg1, arg2, arg3)
+}
+
+// SendDRKeyLvl2Reply mocks base method
+func (m *MockMessenger) SendDRKeyLvl2Reply(arg0 context.Context, arg1 *drkey_mgmt.Lvl2Rep, arg2 net.Addr, arg3 uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendDRKeyLvl2Reply", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendDRKeyLvl2Reply indicates an expected call of SendDRKeyLvl2Reply
+func (mr *MockMessengerMockRecorder) SendDRKeyLvl2Reply(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDRKeyLvl2Reply", reflect.TypeOf((*MockMessenger)(nil).SendDRKeyLvl2Reply), arg0, arg1, arg2, arg3)
 }
 
 // SendHPCfgReply mocks base method
@@ -566,6 +625,34 @@ func (m *MockResponseWriter) SendChainIssueReply(arg0 context.Context, arg1 *cer
 func (mr *MockResponseWriterMockRecorder) SendChainIssueReply(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendChainIssueReply", reflect.TypeOf((*MockResponseWriter)(nil).SendChainIssueReply), arg0, arg1)
+}
+
+// SendDRKeyLvl1Reply mocks base method
+func (m *MockResponseWriter) SendDRKeyLvl1Reply(arg0 context.Context, arg1 *drkey_mgmt.Lvl1Rep) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendDRKeyLvl1Reply", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendDRKeyLvl1Reply indicates an expected call of SendDRKeyLvl1Reply
+func (mr *MockResponseWriterMockRecorder) SendDRKeyLvl1Reply(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDRKeyLvl1Reply", reflect.TypeOf((*MockResponseWriter)(nil).SendDRKeyLvl1Reply), arg0, arg1)
+}
+
+// SendDRKeyLvl2Reply mocks base method
+func (m *MockResponseWriter) SendDRKeyLvl2Reply(arg0 context.Context, arg1 *drkey_mgmt.Lvl2Rep) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendDRKeyLvl2Reply", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendDRKeyLvl2Reply indicates an expected call of SendDRKeyLvl2Reply
+func (mr *MockResponseWriterMockRecorder) SendDRKeyLvl2Reply(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDRKeyLvl2Reply", reflect.TypeOf((*MockResponseWriter)(nil).SendDRKeyLvl2Reply), arg0, arg1)
 }
 
 // SendHPCfgReply mocks base method


### PR DESCRIPTION
6th PR among several in order to port drkey feature to scionlab. Most of the features were first introduced in netsec-ethz#63.

Drkey feature in go/lib/infra.

Some minor changes:
- Renaming functions in messenger.go
- Adapting logging to scionproto#3544
- Regenerating mock_infra
- Changing type in SendLvl1Reply and SendLvl2Reply

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/12)
<!-- Reviewable:end -->
