### PR TITLE
Drkey port pr7

### DIFF
--- a/go/lib/sciond/BUILD.bazel
+++ b/go/lib/sciond/BUILD.bazel
@@ -12,7 +12,9 @@ go_library(
     deps = [
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
+        "//go/lib/ctrl/drkey_mgmt:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
+        "//go/lib/drkey:go_default_library",
         "//go/lib/hostinfo:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/sciond/internal/metrics:go_default_library",

--- a/go/lib/sciond/fake/BUILD.bazel
+++ b/go/lib/sciond/fake/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
+        "//go/lib/drkey:go_default_library",
+        "//go/lib/drkey/protocol:go_default_library",
         "//go/lib/sciond:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/snet:go_default_library",
@@ -24,6 +26,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//go/lib/addr:go_default_library",
+        "//go/lib/drkey:go_default_library",
         "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/xtest:go_default_library",

--- a/go/lib/sciond/fake/fake_test.go
+++ b/go/lib/sciond/fake/fake_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/drkey"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/sciond/fake"
 	"github.com/scionproto/scion/go/lib/snet"
@@ -183,6 +184,27 @@ func TestRevNotificationFromRaw(t *testing.T) {
 func TestRevNotification(t *testing.T) {
 	c := fake.New(&fake.Script{})
 	assert.PanicsWithValue(t, "not implemented", func() { c.RevNotification(nil, nil) })
+}
+
+func TestDRKeyGetLvl2Key(t *testing.T) {
+	c := fake.New(&fake.Script{})
+	srcIA, _ := addr.IAFromString("1-ff00:0:110")
+	dstIA, _ := addr.IAFromString("1-ff00:0:111")
+	srcHost := addr.HostFromIPStr("127.0.0.1")
+	dstHost := addr.HostFromIPStr("127.0.0.2")
+	now := uint32(0)
+	meta := drkey.Lvl2Meta{
+		KeyType:  drkey.Host2Host,
+		Protocol: "piskes",
+		SrcIA:    srcIA,
+		DstIA:    dstIA,
+		SrcHost:  srcHost,
+		DstHost:  dstHost,
+	}
+	tgtKey := xtest.MustParseHexString("19a506e004f23dfefc819c50d69ebece")
+	lvl2Key, err := c.DRKeyGetLvl2Key(context.Background(), meta, now)
+	require.NoError(t, err)
+	assert.EqualValues(t, tgtKey, lvl2Key.Key)
 }
 
 func TestClose(t *testing.T) {

--- a/go/lib/sciond/internal/metrics/metrics.go
+++ b/go/lib/sciond/internal/metrics/metrics.go
@@ -30,6 +30,7 @@ const (
 	subsystemIFInfo     = "if_info"
 	subsystemSVCInfo    = "service_info"
 	subsystemRevocation = "revocation"
+	subsystemDRKey      = "drkey"
 )
 
 // Result values
@@ -65,6 +66,8 @@ var (
 	IFInfos = newIFInfo()
 	// SVCInfos contains metrics for SVC info requests.
 	SVCInfos = newSVCInfo()
+	// DRKeyLvl2Requests contains metrics for DRKeyLvl2 requests.
+	DRKeyLvl2Requests = newDRKeyLvl2Request()
 	// Conns contains metrics for connections to SCIOND.
 	Conns = newConn()
 )
@@ -118,5 +121,12 @@ func newIFInfo() Request {
 	return Request{
 		count: prom.NewCounterVecWithLabels(Namespace, subsystemIFInfo, "requests_total",
 			"The amount of IF info requests sent.", resultLabel{}),
+	}
+}
+
+func newDRKeyLvl2Request() Request {
+	return Request{
+		count: prom.NewCounterVecWithLabels(Namespace, subsystemDRKey, "requests_total",
+			"The amount of DRKeyLvl2 requests sent.", resultLabel{}),
 	}
 }

--- a/go/lib/sciond/mock_sciond/BUILD.bazel
+++ b/go/lib/sciond/mock_sciond/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//go/lib/addr:go_default_library",
         "//go/lib/common:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
+        "//go/lib/drkey:go_default_library",
         "//go/lib/sciond:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/proto:go_default_library",

--- a/go/lib/sciond/mock_sciond/sciond.go
+++ b/go/lib/sciond/mock_sciond/sciond.go
@@ -10,6 +10,7 @@ import (
 	addr "github.com/scionproto/scion/go/lib/addr"
 	common "github.com/scionproto/scion/go/lib/common"
 	path_mgmt "github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	drkey "github.com/scionproto/scion/go/lib/drkey"
 	sciond "github.com/scionproto/scion/go/lib/sciond"
 	snet "github.com/scionproto/scion/go/lib/snet"
 	proto "github.com/scionproto/scion/go/proto"
@@ -105,6 +106,21 @@ func (m *MockConnector) Close(arg0 context.Context) error {
 func (mr *MockConnectorMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockConnector)(nil).Close), arg0)
+}
+
+// DRKeyGetLvl2Key mocks base method
+func (m *MockConnector) DRKeyGetLvl2Key(arg0 context.Context, arg1 drkey.Lvl2Meta, arg2 uint32) (drkey.Lvl2Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DRKeyGetLvl2Key", arg0, arg1, arg2)
+	ret0, _ := ret[0].(drkey.Lvl2Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DRKeyGetLvl2Key indicates an expected call of DRKeyGetLvl2Key
+func (mr *MockConnectorMockRecorder) DRKeyGetLvl2Key(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DRKeyGetLvl2Key", reflect.TypeOf((*MockConnector)(nil).DRKeyGetLvl2Key), arg0, arg1, arg2)
 }
 
 // IFInfo mocks base method

--- a/go/lib/sciond/sciond.go
+++ b/go/lib/sciond/sciond.go
@@ -37,7 +37,9 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/drkey"
 	"github.com/scionproto/scion/go/lib/sciond/internal/metrics"
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/snet"
@@ -101,6 +103,8 @@ type Connector interface {
 	RevNotificationFromRaw(ctx context.Context, b []byte) (*RevReply, error)
 	// RevNotification sends a RevocationInfo message to SCIOND.
 	RevNotification(ctx context.Context, sRevInfo *path_mgmt.SignedRevInfo) (*RevReply, error)
+	// DRKeyGetLvl2Key sends a DRKey Lvl2Key request to SCIOND
+	DRKeyGetLvl2Key(ctx context.Context, meta drkey.Lvl2Meta, valTime uint32) (drkey.Lvl2Key, error)
 	// Close shuts down the connection to a SCIOND server.
 	Close(ctx context.Context) error
 }
@@ -296,6 +300,41 @@ func (c *conn) RevNotification(ctx context.Context,
 	}
 	metrics.Revocations.Inc(metrics.OkSuccess)
 	return reply.RevReply, nil
+}
+
+func (c *conn) DRKeyGetLvl2Key(ctx context.Context, meta drkey.Lvl2Meta,
+	valTime uint32) (drkey.Lvl2Key, error) {
+
+	conn, err := c.connect(ctx)
+	if err != nil {
+		metrics.DRKeyLvl2Requests.Inc(errorToPrometheusLabel(err))
+		return drkey.Lvl2Key{}, serrors.Wrap(ErrUnableToConnect, err)
+	}
+
+	reply, err := roundTrip(
+		&Pld{
+			TraceId: tracing.IDFromCtx(ctx),
+			Which:   proto.SCIONDMsg_Which_drkeyLvl2Req,
+			DRKeyLvl2Req: &drkey_mgmt.Lvl2Req{
+				Protocol:   meta.Protocol,
+				ReqType:    uint8(meta.KeyType),
+				ValTimeRaw: valTime,
+				SrcIARaw:   meta.SrcIA.IAInt(),
+				DstIARaw:   meta.DstIA.IAInt(),
+				SrcHost:    drkey_mgmt.NewHost(meta.SrcHost),
+				DstHost:    drkey_mgmt.NewHost(meta.DstHost),
+			},
+		},
+		conn,
+	)
+	if err != nil {
+		metrics.DRKeyLvl2Requests.Inc(errorToPrometheusLabel(err))
+		return drkey.Lvl2Key{}, serrors.WrapStr("[sciond-API] Failed to send DRKeyLvl2Req", err)
+	}
+	metrics.DRKeyLvl2Requests.Inc(metrics.OkSuccess)
+
+	lvl2rep := reply.DRKeyLvl2Rep
+	return lvl2rep.ToKey(meta), nil
 }
 
 func (c *conn) Close(_ context.Context) error {

--- a/go/lib/sciond/types.go
+++ b/go/lib/sciond/types.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/hostinfo"
 	"github.com/scionproto/scion/go/lib/util"
@@ -74,6 +75,8 @@ type Pld struct {
 	IfInfoReply        *IFInfoReply
 	ServiceInfoRequest *ServiceInfoRequest
 	ServiceInfoReply   *ServiceInfoReply
+	DRKeyLvl2Req       *drkey_mgmt.Lvl2Req `capnp:"drkeyLvl2Req"`
+	DRKeyLvl2Rep       *drkey_mgmt.Lvl2Rep `capnp:"drkeyLvl2Rep"`
 }
 
 func NewPldFromRaw(b common.RawBytes) (*Pld, error) {
@@ -118,6 +121,10 @@ func (p *Pld) union() (interface{}, error) {
 		return p.ServiceInfoRequest, nil
 	case proto.SCIONDMsg_Which_serviceInfoReply:
 		return p.ServiceInfoReply, nil
+	case proto.SCIONDMsg_Which_drkeyLvl2Req:
+		return p.DRKeyLvl2Req, nil
+	case proto.SCIONDMsg_Which_drkeyLvl2Rep:
+		return p.DRKeyLvl2Rep, nil
 	}
 	return nil, common.NewBasicError("Unsupported SCIOND union type", nil, "type", p.Which)
 }


### PR DESCRIPTION
7th PR among several in order to port drkey feature to scionlab. Most of the features were first introduced in netsec-ethz#63.

Drkey feature in go/lib/sciond.

Some minor changes:
- Adapt DRKeyGetLvl2Key to use new connector and metrics
- Extend metrics with DRKey
- Extend fake.go with DRKeyGet2Key
- Regenerate mock_sciond

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/13)
<!-- Reviewable:end -->
