### PR TITLE
Drkey port pr8

### DIFF
--- a/go/lib/drkey/drkeydbsqlite/db_test.go
+++ b/go/lib/drkey/drkeydbsqlite/db_test.go
@@ -74,11 +74,13 @@ func TestDRKeyLvl1(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, drkeyLvl1.Key, newKey.Key)
 
-	rows, err := db.RemoveOutdatedLvl1Keys(ctx, util.TimeToSecs(time.Now().Add(-timeOffset*time.Second)))
+	rows, err := db.RemoveOutdatedLvl1Keys(ctx,
+		util.TimeToSecs(time.Now().Add(-timeOffset*time.Second)))
 	require.NoError(t, err)
 	require.EqualValues(t, 0, rows)
 
-	rows, err = db.RemoveOutdatedLvl1Keys(ctx, util.TimeToSecs(time.Now().Add(2*timeOffset*time.Second)))
+	rows, err = db.RemoveOutdatedLvl1Keys(ctx,
+		util.TimeToSecs(time.Now().Add(2*timeOffset*time.Second)))
 	require.NoError(t, err)
 	require.EqualValues(t, 1, rows)
 
@@ -129,11 +131,13 @@ func TestDRKeyLvl2(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, drkeyLvl2.Key, newKey.Key)
 
-	rows, err := db.RemoveOutdatedLvl2Keys(ctx, util.TimeToSecs(time.Now().Add(-timeOffset*time.Second)))
+	rows, err := db.RemoveOutdatedLvl2Keys(ctx,
+		util.TimeToSecs(time.Now().Add(-timeOffset*time.Second)))
 	require.NoError(t, err)
 	require.EqualValues(t, 0, rows)
 
-	rows, err = db.RemoveOutdatedLvl2Keys(ctx, util.TimeToSecs(time.Now().Add(2*timeOffset*time.Second)))
+	rows, err = db.RemoveOutdatedLvl2Keys(ctx,
+		util.TimeToSecs(time.Now().Add(2*timeOffset*time.Second)))
 	require.NoError(t, err)
 	require.EqualValues(t, 1, rows)
 }
@@ -181,6 +185,8 @@ func TestGetMentionedASes(t *testing.T) {
 		ia("1-ff00:0:111"),
 		ia("2-ff00:0:211"),
 	}
+
+	require.Equal(t, expected, list)
 
 	list, err = db.GetValidLvl1SrcASes(ctx, 3)
 	require.NoError(t, err)

--- a/go/lib/drkey/drkeydbsqlite/lvl1db.go
+++ b/go/lib/drkey/drkeydbsqlite/lvl1db.go
@@ -146,7 +146,9 @@ AND EpochBegin<=? AND ?<EpochEnd
 
 // GetLvl1Key takes an pointer to a first level DRKey and a timestamp at which the DRKey should be
 // valid and returns the corresponding first level DRKey.
-func (b *Lvl1Backend) GetLvl1Key(ctx context.Context, key drkey.Lvl1Meta, valTime uint32) (drkey.Lvl1Key, error) {
+func (b *Lvl1Backend) GetLvl1Key(ctx context.Context, key drkey.Lvl1Meta,
+	valTime uint32) (drkey.Lvl1Key, error) {
+
 	var epochBegin, epochEnd int
 	var bytes []byte
 	err := b.getLvl1KeyStmt.QueryRowContext(ctx, key.SrcIA.I, key.SrcIA.A,
@@ -176,7 +178,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?)
 // InsertLvl1Key inserts a first level DRKey and returns the number of affected rows.
 func (b *Lvl1Backend) InsertLvl1Key(ctx context.Context, key drkey.Lvl1Key) error {
 	_, err := b.insertLvl1KeyStmt.ExecContext(ctx, key.SrcIA.I, key.SrcIA.A, key.DstIA.I,
-		key.DstIA.A, uint32(key.Epoch.NotBefore.Time.Unix()), uint32(key.Epoch.NotAfter.Time.Unix()), key.Key)
+		key.DstIA.A, uint32(key.Epoch.NotBefore.Time.Unix()),
+		uint32(key.Epoch.NotAfter.Time.Unix()), key.Key)
 	if err != nil {
 		return err
 	}

--- a/go/lib/drkey/drkeydbsqlite/lvl2db.go
+++ b/go/lib/drkey/drkeydbsqlite/lvl2db.go
@@ -43,7 +43,8 @@ const (
         EpochBegin  INTEGER NOT NULL,
         EpochEnd    INTEGER NOT NULL,
 		Key 		TEXT NOT NULL,
-		PRIMARY KEY (Protocol, Type, SrcIsdID, SrcAsID, DstIsdID, DstAsID, SrcHostIP, DstHostIP, EpochBegin)
+		PRIMARY KEY (Protocol, Type, SrcIsdID, SrcAsID,` +
+		` DstIsdID, DstAsID, SrcHostIP, DstHostIP, EpochBegin)
 	);`
 )
 
@@ -87,7 +88,9 @@ AND EpochBegin<=? AND ?<EpochEnd
 // GetLvl2Key takes a source, destination and additional ISD-AS, a source, destination and
 // additional host, and a timestamp at which the DRKey should be valid and
 // returns a second level DRKey of the request type
-func (b *Lvl2Backend) GetLvl2Key(ctx context.Context, key drkey.Lvl2Meta, valTime uint32) (drkey.Lvl2Key, error) {
+func (b *Lvl2Backend) GetLvl2Key(ctx context.Context, key drkey.Lvl2Meta,
+	valTime uint32) (drkey.Lvl2Key, error) {
+
 	var epochBegin int
 	var epochEnd int
 	var bytes []byte

--- a/go/lib/drkey/protocol/delegated.go
+++ b/go/lib/drkey/protocol/delegated.go
@@ -64,7 +64,7 @@ func (p Delegated) DeriveLvl2FromDS(meta drkey.Lvl2Meta, ds drkey.DelegationSecr
 		b := meta.SrcHost.Pack()
 		buffs = [][]byte{
 			b,
-			[]byte{byte(len(b))},
+			{byte(len(b))},
 		}
 		pLen += len(b) + 1
 		fallthrough

--- a/go/lib/drkey/protocol/standard.go
+++ b/go/lib/drkey/protocol/standard.go
@@ -49,7 +49,7 @@ func (p Standard) DeriveLvl2(meta drkey.Lvl2Meta, key drkey.Lvl1Key) (drkey.Lvl2
 		b := meta.SrcHost.Pack()
 		buffs = [][]byte{
 			b,
-			[]byte{byte(len(b))},
+			{byte(len(b))},
 		}
 		pLen += len(b) + 1
 		fallthrough

--- a/go/lib/drkeystorage/config.go
+++ b/go/lib/drkeystorage/config.go
@@ -133,7 +133,7 @@ func (cfg *DRKeyDBConf) Sample(dst io.Writer, path config.Path, ctx config.CtxMa
 
 // ConfigName is the key in the toml file.
 func (cfg *DRKeyDBConf) ConfigName() string {
-	return "drkeyDB"
+	return "drkey_db"
 }
 
 // newDB is an internal function that returns a new drkey DB. Call this with a pointer to

--- a/go/lib/infra/messenger/messenger.go
+++ b/go/lib/infra/messenger/messenger.go
@@ -715,7 +715,8 @@ func (m *Messenger) GetDRKeyLvl1(ctx context.Context, msg *drkey_mgmt.Lvl1Req, a
 	replyCtrlPld, err :=
 		m.getFallbackRequester(infra.DRKeyLvl1Request).Request(ctx, pld, a, false)
 	if err != nil {
-		return nil, common.NewBasicError("[Messenger] Request error", err, "req_type", infra.DRKeyLvl1Request)
+		return nil, common.NewBasicError("[Messenger] Request error", err,
+			"req_type", infra.DRKeyLvl1Request)
 	}
 	_, replyMsg, err := Validate(replyCtrlPld)
 	if err != nil {
@@ -755,7 +756,8 @@ func (m *Messenger) GetDRKeyLvl2(ctx context.Context, msg *drkey_mgmt.Lvl2Req, a
 	replyCtrlPld, err :=
 		m.getFallbackRequester(infra.DRKeyLvl2Request).Request(ctx, pld, a, false)
 	if err != nil {
-		return nil, common.NewBasicError("[Messenger] Request error", err, "req_type", infra.DRKeyLvl2Request)
+		return nil, common.NewBasicError("[Messenger] Request error", err,
+			"req_type", infra.DRKeyLvl2Request)
 	}
 	_, replyMsg, err := Validate(replyCtrlPld)
 	if err != nil {

--- a/go/lib/infra/messenger/quic_response_writer.go
+++ b/go/lib/infra/messenger/quic_response_writer.go
@@ -136,7 +136,8 @@ func (rw *QUICResponseWriter) SendHPCfgReply(ctx context.Context, msg *path_mgmt
 	return rw.sendMessage(ctrlPld)
 }
 
-func (rw *QUICResponseWriter) SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1Rep) error {
+func (rw *QUICResponseWriter) SendDRKeyLvl1Reply(ctx context.Context,
+	msg *drkey_mgmt.Lvl1Rep) error {
 	go func() {
 		defer log.HandlePanic()
 		<-ctx.Done()
@@ -149,7 +150,8 @@ func (rw *QUICResponseWriter) SendDRKeyLvl1Reply(ctx context.Context, msg *drkey
 	return rw.sendMessage(ctrlPld)
 }
 
-func (rw *QUICResponseWriter) SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2Rep) error {
+func (rw *QUICResponseWriter) SendDRKeyLvl2Reply(ctx context.Context,
+	msg *drkey_mgmt.Lvl2Rep) error {
 	go func() {
 		defer log.HandlePanic()
 		<-ctx.Done()

--- a/go/lib/infra/messenger/tcp/BUILD.bazel
+++ b/go/lib/infra/messenger/tcp/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//go/lib/ctrl:go_default_library",
         "//go/lib/ctrl/ack:go_default_library",
         "//go/lib/ctrl/cert_mgmt:go_default_library",
+        "//go/lib/ctrl/drkey_mgmt:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
         "//go/lib/infra:go_default_library",
         "//go/lib/infra/messenger:go_default_library",

--- a/go/lib/infra/messenger/tcp/messenger.go
+++ b/go/lib/infra/messenger/tcp/messenger.go
@@ -25,6 +25,7 @@ import (
 	"github.com/scionproto/scion/go/lib/ctrl"
 	"github.com/scionproto/scion/go/lib/ctrl/ack"
 	"github.com/scionproto/scion/go/lib/ctrl/cert_mgmt"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
@@ -183,6 +184,35 @@ func (m *Messenger) GetSegs(ctx context.Context, msg *path_mgmt.SegReq, a net.Ad
 		return nil, serrors.New("[tcp-msger] Type assertion failed",
 			"msg", replyMsg, "type", "*path_mgmt.SegReply")
 	}
+}
+
+// GetDRKeyLvl2 requests to the remote server the DRKeyLvl2 key which
+// matches the payload content and return a verified reply.
+func (m *Messenger) GetDRKeyLvl2(ctx context.Context, msg *drkey_mgmt.Lvl2Req, a net.Addr,
+	id uint64) (*drkey_mgmt.Lvl2Rep, error) {
+
+	logger := log.FromCtx(ctx)
+	pld, err := ctrl.NewDRKeyMgmtPld(msg, nil, &ctrl.Data{ReqId: id})
+	if err != nil {
+		return nil, err
+	}
+	logger.Debug("[tcp-msger] Sending request", "req_type", infra.DRKeyLvl2Request,
+		"msg_id", id, "request", msg, "peer", a)
+	replyCtrlPld, err := m.Client.Request(ctx, pld, a)
+	if err != nil {
+		return nil, serrors.WrapStr("[tcp-msger] request error", err, "req_type", infra.DRKeyLvl2Request)
+	}
+	_, replyMsg, err := messenger.Validate(replyCtrlPld)
+	if err != nil {
+		return nil, serrors.WrapStr("[tcp-msger] reply validation failed", err)
+	}
+	reply, ok := replyMsg.(*drkey_mgmt.Lvl2Rep)
+	if !ok {
+		return nil, serrors.New("[tcp-msger] Type assertion failed",
+			"msg", reply, "type", "*drkey_mgmt.Lvl2Rep")
+	}
+	logger.Debug("[tcp-msger] Received reply")
+	return reply, nil
 }
 
 func (m *Messenger) AddHandler(msgType infra.MessageType, h infra.Handler) {

--- a/go/lib/infra/messenger/tcp/messenger.go
+++ b/go/lib/infra/messenger/tcp/messenger.go
@@ -200,7 +200,8 @@ func (m *Messenger) GetDRKeyLvl2(ctx context.Context, msg *drkey_mgmt.Lvl2Req, a
 		"msg_id", id, "request", msg, "peer", a)
 	replyCtrlPld, err := m.Client.Request(ctx, pld, a)
 	if err != nil {
-		return nil, serrors.WrapStr("[tcp-msger] request error", err, "req_type", infra.DRKeyLvl2Request)
+		return nil, serrors.WrapStr("[tcp-msger] request error", err,
+			"req_type", infra.DRKeyLvl2Request)
 	}
 	_, replyMsg, err := messenger.Validate(replyCtrlPld)
 	if err != nil {

--- a/go/lib/infra/messenger/udp_response_writer.go
+++ b/go/lib/infra/messenger/udp_response_writer.go
@@ -69,9 +69,11 @@ func (rw *UDPResponseWriter) SendHPCfgReply(ctx context.Context, msg *path_mgmt.
 	return rw.Messenger.SendHPCfgReply(ctx, msg, rw.Remote, rw.ID)
 }
 
-func (rw *UDPResponseWriter) SendDRKeyLvl1Reply(ctx context.Context, msg *drkey_mgmt.Lvl1Rep) error {
+func (rw *UDPResponseWriter) SendDRKeyLvl1Reply(ctx context.Context,
+	msg *drkey_mgmt.Lvl1Rep) error {
 	return rw.Messenger.SendDRKeyLvl1Reply(ctx, msg, rw.Remote, rw.ID)
 }
-func (rw *UDPResponseWriter) SendDRKeyLvl2Reply(ctx context.Context, msg *drkey_mgmt.Lvl2Rep) error {
+func (rw *UDPResponseWriter) SendDRKeyLvl2Reply(ctx context.Context,
+	msg *drkey_mgmt.Lvl2Rep) error {
 	return rw.Messenger.SendDRKeyLvl2Reply(ctx, msg, rw.Remote, rw.ID)
 }

--- a/go/sciond/BUILD.bazel
+++ b/go/sciond/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//go/lib/common:go_default_library",
+        "//go/lib/drkeystorage:go_default_library",
         "//go/lib/env:go_default_library",
         "//go/lib/fatal:go_default_library",
         "//go/lib/infra:go_default_library",
@@ -27,6 +28,7 @@ go_library(
         "//go/lib/topology:go_default_library",
         "//go/proto:go_default_library",
         "//go/sciond/internal/config:go_default_library",
+        "//go/sciond/internal/drkey:go_default_library",
         "//go/sciond/internal/fetcher:go_default_library",
         "//go/sciond/internal/servers:go_default_library",
         "@com_github_burntsushi_toml//:go_default_library",

--- a/go/sciond/internal/config/BUILD.bazel
+++ b/go/sciond/internal/config/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//go/sciond:__subpackages__"],
     deps = [
         "//go/lib/config:go_default_library",
+        "//go/lib/drkeystorage:go_default_library",
         "//go/lib/env:go_default_library",
         "//go/lib/log:go_default_library",
         "//go/lib/pathstorage:go_default_library",

--- a/go/sciond/internal/config/config.go
+++ b/go/sciond/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/config"
+	"github.com/scionproto/scion/go/lib/drkeystorage"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/log"
 	"github.com/scionproto/scion/go/lib/pathstorage"
@@ -44,7 +45,9 @@ type Config struct {
 	TrustDB  truststorage.TrustDBConf `toml:"trust_db,omitempty"`
 	// PathDB contains the configuration for the PathDB connection.
 	PathDB pathstorage.PathDBConf `toml:"path_db,omitempty"`
-	SD     SDConfig               `toml:"sd,omitempty"`
+	// DRKeyDB contains the DRKey DB configuration.
+	DRKeyDB drkeystorage.DRKeyDBConf `toml:"drkey_db,omitempty"`
+	SD      SDConfig                 `toml:"sd,omitempty"`
 }
 
 func (cfg *Config) InitDefaults() {
@@ -56,6 +59,7 @@ func (cfg *Config) InitDefaults() {
 		&cfg.Tracing,
 		&cfg.TrustDB,
 		&cfg.PathDB,
+		&cfg.DRKeyDB,
 		&cfg.SD,
 	)
 }
@@ -68,6 +72,7 @@ func (cfg *Config) Validate() error {
 		&cfg.Metrics,
 		&cfg.TrustDB,
 		&cfg.PathDB,
+		&cfg.DRKeyDB,
 		&cfg.SD,
 	)
 }
@@ -81,6 +86,7 @@ func (cfg *Config) Sample(dst io.Writer, path config.Path, _ config.CtxMap) {
 		&cfg.Tracing,
 		&cfg.TrustDB,
 		&cfg.PathDB,
+		&cfg.DRKeyDB,
 		&cfg.SD,
 	)
 }

--- a/go/sciond/internal/drkey/BUILD.bazel
+++ b/go/sciond/internal/drkey/BUILD.bazel
@@ -7,12 +7,12 @@ go_library(
     visibility = ["//go/sciond:__subpackages__"],
     deps = [
         "//go/lib/addr:go_default_library",
-        "//go/lib/common:go_default_library",
         "//go/lib/ctrl/drkey_mgmt:go_default_library",
         "//go/lib/drkey:go_default_library",
         "//go/lib/drkeystorage:go_default_library",
         "//go/lib/infra/messenger:go_default_library",
         "//go/lib/log:go_default_library",
+        "//go/lib/serrors:go_default_library",
         "//go/lib/snet:go_default_library",
         "//go/lib/util:go_default_library",
     ],

--- a/go/sciond/internal/drkey/BUILD.bazel
+++ b/go/sciond/internal/drkey/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["client_store.go"],
+    importpath = "github.com/scionproto/scion/go/sciond/internal/drkey",
+    visibility = ["//go/sciond:__subpackages__"],
+    deps = [
+        "//go/lib/addr:go_default_library",
+        "//go/lib/common:go_default_library",
+        "//go/lib/ctrl/drkey_mgmt:go_default_library",
+        "//go/lib/drkey:go_default_library",
+        "//go/lib/drkeystorage:go_default_library",
+        "//go/lib/infra/messenger:go_default_library",
+        "//go/lib/log:go_default_library",
+        "//go/lib/snet:go_default_library",
+        "//go/lib/util:go_default_library",
+    ],
+)

--- a/go/sciond/internal/drkey/client_store.go
+++ b/go/sciond/internal/drkey/client_store.go
@@ -1,0 +1,91 @@
+// Copyright 2019 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package drkey
+
+import (
+	"context"
+	"database/sql"
+	"net"
+	"time"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
+	"github.com/scionproto/scion/go/lib/drkey"
+	"github.com/scionproto/scion/go/lib/drkeystorage"
+	"github.com/scionproto/scion/go/lib/infra/messenger"
+	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/snet"
+	"github.com/scionproto/scion/go/lib/util"
+)
+
+type DRKeyLvl2Requester interface {
+	GetDRKeyLvl2(ctx context.Context, msg *drkey_mgmt.Lvl2Req, a net.Addr,
+		id uint64) (*drkey_mgmt.Lvl2Rep, error)
+}
+
+// ClientStore is the DRKey store used in the client side, i.e. sciond.
+// It implements drkeystorage.ClientStore.
+type ClientStore struct {
+	ia        addr.IA
+	db        drkey.Lvl2DB
+	requester DRKeyLvl2Requester
+}
+
+var _ drkeystorage.ClientStore = &ClientStore{}
+
+// NewClientStore constructs a new client store without assigned messenger.
+func NewClientStore(local addr.IA, db drkey.Lvl2DB, requester DRKeyLvl2Requester) *ClientStore {
+	return &ClientStore{
+		ia:        local,
+		db:        db,
+		requester: requester,
+	}
+}
+
+// GetLvl2Key returns the level 2 drkey from the local DB or if not found, by asking our local CS.
+func (s *ClientStore) GetLvl2Key(ctx context.Context, meta drkey.Lvl2Meta,
+	valTime time.Time) (drkey.Lvl2Key, error) {
+
+	logger := log.FromCtx(ctx)
+	// is it in storage?
+	k, err := s.db.GetLvl2Key(ctx, meta, util.TimeToSecs(valTime))
+	if err == nil {
+		return k, err
+	}
+	if err != sql.ErrNoRows {
+		return drkey.Lvl2Key{}, common.NewBasicError("Cannot retrieve key from DB", err)
+	}
+	logger.Trace("[DRKey ClientStore] Level 2 key not stored. Requesting it to CS")
+	// if not, ask our CS for it
+	req := drkey_mgmt.NewLvl2ReqFromMeta(meta, valTime)
+	csAddress := &snet.SVCAddr{IA: s.ia, SVC: addr.SvcCS}
+	rep, err := s.requester.GetDRKeyLvl2(ctx, &req, csAddress, messenger.NextId())
+	if err != nil {
+		return drkey.Lvl2Key{},
+			common.NewBasicError("Error sending DRKey lvl2 request via messenger", err)
+	}
+	k = rep.ToKey(meta)
+	if err = s.db.InsertLvl2Key(ctx, k); err != nil {
+		logger.Error("[DRKey ClientStore] Could not insert level 2 in DB", err)
+	}
+	return k, nil
+}
+
+// DeleteExpiredKeys will remove any expired keys.
+func (s *ClientStore) DeleteExpiredKeys(ctx context.Context) (int, error) {
+	i, err := s.db.RemoveOutdatedLvl2Keys(ctx, util.TimeToSecs(time.Now()))
+	return int(i), err
+}

--- a/go/sciond/internal/drkey/client_store.go
+++ b/go/sciond/internal/drkey/client_store.go
@@ -21,14 +21,21 @@ import (
 	"time"
 
 	"github.com/scionproto/scion/go/lib/addr"
-	"github.com/scionproto/scion/go/lib/common"
 	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/drkey"
 	"github.com/scionproto/scion/go/lib/drkeystorage"
 	"github.com/scionproto/scion/go/lib/infra/messenger"
 	"github.com/scionproto/scion/go/lib/log"
+	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/snet"
 	"github.com/scionproto/scion/go/lib/util"
+)
+
+// Drkey fetching errors.
+var (
+	ErrDB        = serrors.New("error with DB")
+	ErrInsertDB  = serrors.New("error inserting in DB")
+	ErrMessenger = serrors.New("error with Messenger")
 )
 
 type DRKeyLvl2Requester interface {
@@ -66,7 +73,7 @@ func (s *ClientStore) GetLvl2Key(ctx context.Context, meta drkey.Lvl2Meta,
 		return k, err
 	}
 	if err != sql.ErrNoRows {
-		return drkey.Lvl2Key{}, common.NewBasicError("Cannot retrieve key from DB", err)
+		return drkey.Lvl2Key{}, serrors.Wrap(ErrDB, err)
 	}
 	logger.Trace("[DRKey ClientStore] Level 2 key not stored. Requesting it to CS")
 	// if not, ask our CS for it
@@ -74,12 +81,12 @@ func (s *ClientStore) GetLvl2Key(ctx context.Context, meta drkey.Lvl2Meta,
 	csAddress := &snet.SVCAddr{IA: s.ia, SVC: addr.SvcCS}
 	rep, err := s.requester.GetDRKeyLvl2(ctx, &req, csAddress, messenger.NextId())
 	if err != nil {
-		return drkey.Lvl2Key{},
-			common.NewBasicError("Error sending DRKey lvl2 request via messenger", err)
+		return drkey.Lvl2Key{}, serrors.Wrap(ErrMessenger, err)
 	}
 	k = rep.ToKey(meta)
 	if err = s.db.InsertLvl2Key(ctx, k); err != nil {
-		logger.Error("[DRKey ClientStore] Could not insert level 2 in DB", err)
+		logger.Error("[DRKey ClientStore] Could not insert level 2 in DB", "error", err)
+		return k, serrors.Wrap(ErrInsertDB, err)
 	}
 	return k, nil
 }

--- a/go/sciond/internal/metrics/metrics.go
+++ b/go/sciond/internal/metrics/metrics.go
@@ -32,6 +32,7 @@ const (
 	subsystemIFInfo     = "if_info"
 	subsystemSVCInfo    = "service_info"
 	subsystemRevocation = "revocation"
+	subsystemDRKey      = "drkey"
 )
 
 // Revocation sources
@@ -64,6 +65,8 @@ var (
 	IFInfos = newIFInfo()
 	// SVCInfos contains metrics for SVC info requests.
 	SVCInfos = newSVCInfo()
+	// DRKeyLvl2Requests contains metrics for DRKeyLvl2 requests.
+	DRKeyLvl2Requests = newDRKeyLvl2Request()
 )
 
 type resultLabel struct {
@@ -225,6 +228,16 @@ func newIFInfo() Request {
 			"The amount of IF info requests received.", resultLabel{}),
 		latency: prom.NewHistogramVecWithLabels(Namespace, subsystemIFInfo,
 			"request_duration_seconds", "Time to handle IF info requests.",
+			resultLabel{}, prom.DefaultLatencyBuckets),
+	}
+}
+
+func newDRKeyLvl2Request() Request {
+	return Request{
+		count: prom.NewCounterVecWithLabels(Namespace, subsystemDRKey, "requests_total",
+			"The amount of DRKeyLvl2 requests sent.", resultLabel{}),
+		latency: prom.NewHistogramVecWithLabels(Namespace, subsystemDRKey,
+			"request_duration_seconds", "Time to handle DRKey requests.",
 			resultLabel{}, prom.DefaultLatencyBuckets),
 	}
 }

--- a/go/sciond/internal/servers/BUILD.bazel
+++ b/go/sciond/internal/servers/BUILD.bazel
@@ -11,7 +11,9 @@ go_library(
     visibility = ["//go/sciond:__subpackages__"],
     deps = [
         "//go/lib/common:go_default_library",
+        "//go/lib/ctrl/drkey_mgmt:go_default_library",
         "//go/lib/ctrl/path_mgmt:go_default_library",
+        "//go/lib/drkeystorage:go_default_library",
         "//go/lib/hostinfo:go_default_library",
         "//go/lib/infra:go_default_library",
         "//go/lib/infra/modules/itopo:go_default_library",
@@ -22,6 +24,7 @@ go_library(
         "//go/lib/sciond:go_default_library",
         "//go/lib/serrors:go_default_library",
         "//go/lib/tracing:go_default_library",
+        "//go/lib/util:go_default_library",
         "//go/proto:go_default_library",
         "//go/sciond/internal/fetcher:go_default_library",
         "//go/sciond/internal/metrics:go_default_library",

--- a/go/sciond/internal/servers/BUILD.bazel
+++ b/go/sciond/internal/servers/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//go/lib/tracing:go_default_library",
         "//go/lib/util:go_default_library",
         "//go/proto:go_default_library",
+        "//go/sciond/internal/drkey:go_default_library",
         "//go/sciond/internal/fetcher:go_default_library",
         "//go/sciond/internal/metrics:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -20,7 +20,9 @@ import (
 	"net"
 	"time"
 
+	"github.com/scionproto/scion/go/lib/ctrl/drkey_mgmt"
 	"github.com/scionproto/scion/go/lib/ctrl/path_mgmt"
+	"github.com/scionproto/scion/go/lib/drkeystorage"
 	"github.com/scionproto/scion/go/lib/hostinfo"
 	"github.com/scionproto/scion/go/lib/infra"
 	"github.com/scionproto/scion/go/lib/infra/modules/itopo"
@@ -30,6 +32,7 @@ import (
 	"github.com/scionproto/scion/go/lib/revcache"
 	"github.com/scionproto/scion/go/lib/sciond"
 	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
 	"github.com/scionproto/scion/go/sciond/internal/fetcher"
 	"github.com/scionproto/scion/go/sciond/internal/metrics"
@@ -324,6 +327,45 @@ func (h *RevNotificationHandler) verifySRevInfo(ctx context.Context,
 	}
 	err = segverifier.VerifyRevInfo(ctx, h.VerifierFactory.NewVerifier(), nil, sRevInfo)
 	return info, err
+}
+
+// DrKeyLvl2RequestHandler represents the shared global state for the handling of all
+// DrKeyLvl2Request queries. The SCIOND API spawns a goroutine with method Handle
+// for each DrKeyLvl2Request it receives.
+type DrKeyLvl2RequestHandler struct {
+	Store drkeystorage.ClientStore
+}
+
+func (h *DrKeyLvl2RequestHandler) Handle(ctx context.Context, conn net.Conn,
+	src net.Addr, pld *sciond.Pld) {
+
+	defer conn.Close()
+	req := pld.DRKeyLvl2Req
+	metricsDone := metrics.DRKeyLvl2Requests.Start()
+	logger := log.FromCtx(ctx)
+	logger.Debug("[DrKeyLvl2RequestHandler] Received request", "req", req)
+	workCtx, workCancelF := context.WithTimeout(ctx, DefaultWorkTimeout)
+	defer workCancelF()
+
+	key, err := h.Store.GetLvl2Key(workCtx, req.ToMeta(), util.SecsToTime(req.ValTimeRaw))
+	if err != nil {
+		logger.Error("Error sending DRKey lvl2 request via messenger", "err", err)
+		metricsDone(metrics.ErrDB)
+		return
+	}
+
+	replyToSend := &sciond.Pld{
+		Id:           pld.Id,
+		Which:        proto.SCIONDMsg_Which_drkeyLvl2Rep,
+		DRKeyLvl2Rep: drkey_mgmt.NewLvl2RepFromKey(key, time.Now()),
+	}
+	if err := sciond.Send(replyToSend, conn); err != nil {
+		logger.Warn("Unable to reply to client", "client", src, "err", err, "reply", replyToSend)
+		metricsDone(metrics.ErrNetwork)
+	} else {
+		logger.Trace("Sent reply", "DRKeyLvl2Rep", drkey_mgmt.Lvl2Rep{})
+		metricsDone(metrics.OkSuccess)
+	}
 }
 
 // isValid is a placeholder. It should return true if and only if revocation

--- a/go/sciond/internal/servers/handlers.go
+++ b/go/sciond/internal/servers/handlers.go
@@ -16,6 +16,7 @@ package servers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -34,6 +35,7 @@ import (
 	"github.com/scionproto/scion/go/lib/serrors"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/proto"
+	"github.com/scionproto/scion/go/sciond/internal/drkey"
 	"github.com/scionproto/scion/go/sciond/internal/fetcher"
 	"github.com/scionproto/scion/go/sciond/internal/metrics"
 )
@@ -342,6 +344,7 @@ func (h *DrKeyLvl2RequestHandler) Handle(ctx context.Context, conn net.Conn,
 	defer conn.Close()
 	req := pld.DRKeyLvl2Req
 	metricsDone := metrics.DRKeyLvl2Requests.Start()
+	label := metrics.OkSuccess
 	logger := log.FromCtx(ctx)
 	logger.Debug("[DrKeyLvl2RequestHandler] Received request", "req", req)
 	workCtx, workCancelF := context.WithTimeout(ctx, DefaultWorkTimeout)
@@ -349,9 +352,21 @@ func (h *DrKeyLvl2RequestHandler) Handle(ctx context.Context, conn net.Conn,
 
 	key, err := h.Store.GetLvl2Key(workCtx, req.ToMeta(), util.SecsToTime(req.ValTimeRaw))
 	if err != nil {
-		logger.Error("Error sending DRKey lvl2 request via messenger", "err", err)
-		metricsDone(metrics.ErrDB)
-		return
+		if errors.Is(err, drkey.ErrDB) {
+			label = metrics.ErrDB
+		} else {
+			switch {
+			case errors.Is(err, drkey.ErrMessenger):
+				label = metrics.ErrNetwork
+			case errors.Is(err, drkey.ErrInsertDB):
+				label = metrics.ErrDB
+			default:
+				label = metrics.ErrNotClassified
+			}
+			logger.Error("Error getting Lvl2Key", "err", err)
+			metricsDone(label)
+			return
+		}
 	}
 
 	replyToSend := &sciond.Pld{
@@ -364,7 +379,7 @@ func (h *DrKeyLvl2RequestHandler) Handle(ctx context.Context, conn net.Conn,
 		metricsDone(metrics.ErrNetwork)
 	} else {
 		logger.Trace("Sent reply", "DRKeyLvl2Rep", drkey_mgmt.Lvl2Rep{})
-		metricsDone(metrics.OkSuccess)
+		metricsDone(label)
 	}
 }
 

--- a/go/sciond/main.go
+++ b/go/sciond/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/scionproto/scion/go/lib/common"
+	"github.com/scionproto/scion/go/lib/drkeystorage"
 	"github.com/scionproto/scion/go/lib/env"
 	"github.com/scionproto/scion/go/lib/fatal"
 	"github.com/scionproto/scion/go/lib/infra"
@@ -49,6 +50,7 @@ import (
 	"github.com/scionproto/scion/go/lib/topology"
 	"github.com/scionproto/scion/go/proto"
 	"github.com/scionproto/scion/go/sciond/internal/config"
+	"github.com/scionproto/scion/go/sciond/internal/drkey"
 	"github.com/scionproto/scion/go/sciond/internal/fetcher"
 	"github.com/scionproto/scion/go/sciond/internal/servers"
 )
@@ -167,6 +169,24 @@ func realMain() int {
 			VerifierFactory:  verificationFactory{Provider: trustStore},
 			NextQueryCleaner: segfetcher.NextQueryCleaner{PathDB: pathDB},
 		},
+	}
+
+	drkeyEnabled := cfg.DRKeyDB.Connection() != ""
+	log.Info("DRKey", "enabled", drkeyEnabled)
+	if drkeyEnabled {
+		drkeyDB, err := cfg.DRKeyDB.NewLvl2DB()
+		if err != nil {
+			log.Crit("Unable to initialize drkey storage", "err", err)
+			return 1
+		}
+		defer drkeyDB.Close()
+		drkeyStore := drkey.NewClientStore(itopo.Get().IA(), drkeyDB, msger)
+		drkeyCleaner := periodic.Start(drkeystorage.NewStoreCleaner(drkeyStore),
+			time.Hour, 10*time.Minute)
+		defer drkeyCleaner.Stop()
+		handlers[proto.SCIONDMsg_Which_drkeyLvl2Req] = &servers.DrKeyLvl2RequestHandler{
+			Store: drkeyStore,
+		}
 	}
 	cleaner := periodic.Start(pathdb.NewCleaner(pathDB, "sd_segments"),
 		300*time.Second, 295*time.Second)


### PR DESCRIPTION
8th PR among several in order to port drkey feature to scionlab. Most of the features were first introduced in netsec-ethz#63.

DRKey feature in go/sciond/.

Some changes, including:
- Adapting drkey handler
- Adapting to metrics
- Refactoring name for config.go drkeystorage
- Apating drkey handler initialization in main.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/14)
<!-- Reviewable:end -->
