### PR TITLE
colibri command.

### DIFF
--- a/go/lib/colibri/listing.go
+++ b/go/lib/colibri/listing.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scionproto/scion/go/lib/colibri/reservation"
 )
 
+// TODO(juagargi) rename to something like SegRsvInfo
 type ReservationLooks struct {
 	Id             reservation.ID
 	SrcIA          addr.IA // might be different than the Id.ASID if the segment is e.g. down

--- a/go/pkg/scioncolibrisubcmd/BUILD.bazel
+++ b/go/pkg/scioncolibrisubcmd/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//lint:go.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "colibrisubcmd.go",
+        "config.go",
+    ],
+    importpath = "github.com/scionproto/scion/go/pkg/scioncolibrisubcmd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//go/co/reservation:go_default_library",
+        "//go/lib/addr:go_default_library",
+        "//go/lib/colibri:go_default_library",
+        "//go/lib/daemon:go_default_library",
+        "//go/lib/serrors:go_default_library",
+        "@com_github_fatih_color//:go_default_library",
+    ],
+)

--- a/go/pkg/scioncolibrisubcmd/colibrisubcmd.go
+++ b/go/pkg/scioncolibrisubcmd/colibrisubcmd.go
@@ -1,0 +1,159 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colibrisubcmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/scionproto/scion/go/co/reservation"
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/colibri"
+	"github.com/scionproto/scion/go/lib/daemon"
+	"github.com/scionproto/scion/go/lib/serrors"
+)
+
+type Result struct {
+	Destination       addr.IA
+	Stitchables       *colibri.StitchableSegments
+	Trips             []*colibri.FullTrip
+	ComputedFullTrips int
+}
+
+func (r Result) Human(w io.Writer, colored bool) {
+	cs := DefaultColorScheme(!colored)
+
+	fmt.Fprintln(w, cs.Header.Sprint("Stitchable Segments:"))
+	humanSegLooks(w, cs, cs.Type.Sprint("   up"), r.Stitchables.Up)
+	humanSegLooks(w, cs, cs.Type.Sprint(" core"), r.Stitchables.Core)
+	humanSegLooks(w, cs, cs.Type.Sprint(" down"), r.Stitchables.Down)
+
+	fmt.Fprintln(w, cs.Header.Sprint("Full Trips:"))
+	humanFulTrips(w, cs, r.Trips)
+}
+
+func (r Result) JSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+	return enc.Encode(r)
+}
+
+func Run(ctx context.Context, dst addr.IA, cfg Config) (*Result, error) {
+	sdConn, err := daemon.NewService(cfg.Daemon).Connect(ctx)
+	if err != nil {
+		return nil, serrors.WrapStr("connecting to the SCION Daemon", err, "addr", cfg.Daemon)
+	}
+
+	stSegs, err := sdConn.ColibriListRsvs(ctx, dst)
+	if err != nil {
+		return nil, serrors.WrapStr("listing segment reservations", err)
+	}
+	fullTrips := colibri.CombineAll(stSegs)
+	computedFullTripCount := len(fullTrips)
+	if cfg.MaxFullTrips < len(fullTrips) {
+		fullTrips = fullTrips[:cfg.MaxFullTrips]
+	}
+	// after combination, trim the stitchable segments for displaying
+	limitNumberOfStitchableSegs(cfg.MaxStitRsvs, stSegs)
+
+	return &Result{
+		Destination:       dst,
+		Stitchables:       stSegs,
+		Trips:             fullTrips,
+		ComputedFullTrips: computedFullTripCount,
+	}, nil
+}
+
+func limitNumberOfStitchableSegs(max int, stSegs *colibri.StitchableSegments) {
+	limit := func(m int, looks *[]*colibri.ReservationLooks) {
+		if m < len(*looks) {
+			*looks = (*looks)[:m]
+		}
+	}
+	limit(max, &stSegs.Up)
+	limit(max, &stSegs.Core)
+	limit(max, &stSegs.Down)
+}
+
+func humanSegLooks(w io.Writer, cs ColorScheme, ptype string, looks []*colibri.ReservationLooks) {
+	idxWidth := int(math.Log10(float64(len(looks)))) + 1
+	for i, look := range looks {
+		fmt.Fprintf(w, "[%*d] %6s %s\n", idxWidth, i, ptype, humanSegLook(cs, look))
+	}
+}
+
+func humanSegLook(cs ColorScheme, look *colibri.ReservationLooks) string {
+	return strings.Join(cs.KeyValues(
+		"ID", look.Id.String(),
+		"bw", fmt.Sprintf("%3d", look.AllocBW),
+		"steps", humanPathSteps(cs, look.Path),
+		"Expiration", humanStatus(cs, look.ExpirationTime.UTC()),
+	), " ")
+}
+
+func humanPathSteps(cs ColorScheme, steps []reservation.PathStep) string {
+	if len(steps) < 2 {
+		panic(fmt.Sprintf("length of reservation (%d) is wrong, with steps: %v", len(steps), steps))
+	}
+	strs := make([]string, len(steps))
+	strs[0] = fmt.Sprintf("%s %s", cs.Values.Sprint(steps[0].IA), cs.Intf.Sprint(steps[0].Egress))
+	for i := 1; i < len(steps)-1; i++ {
+		step := steps[i]
+		strs[i] = fmt.Sprintf("%s %s %s",
+			cs.Intf.Sprint(step.Ingress),
+			cs.Values.Sprint(step.IA),
+			cs.Intf.Sprint(step.Egress))
+	}
+	strs[len(strs)-1] = fmt.Sprintf("%s %s", cs.Intf.Sprint(steps[len(steps)-1].Ingress),
+		cs.Values.Sprint(steps[len(steps)-1].IA))
+	return strings.Join(strs, cs.Link.Sprint(">"))
+}
+
+func humanStatus(cs ColorScheme, expTime time.Time) string {
+	t := expTime.Format(time.Stamp)
+	if time.Now().After(expTime) {
+		return cs.Bad.Sprint(t)
+	}
+	return cs.Good.Sprint(t)
+}
+
+func humanFulTrips(w io.Writer, cs ColorScheme, fullTrips []*colibri.FullTrip) {
+	idxWidth := int(math.Log10(float64(len(fullTrips)))) + 1
+	for i, ft := range fullTrips {
+		fmt.Fprintf(w, "[%*d] %s\n", idxWidth, i, humanFullTrip(cs, *ft))
+	}
+}
+
+func humanFullTrip(cs ColorScheme, ft colibri.FullTrip) string {
+	stitches := make([]string, len(ft))
+	for i, s := range ft {
+		stitches[i] = fmt.Sprintf("%s (ID %s)--> %s",
+			s.SrcIA,
+			cs.Intf.Sprint(s.Id),
+			s.DstIA)
+	}
+	return strings.Join(cs.KeyValues(
+		"bw", fmt.Sprintf("%3d", ft.AllocBW()),
+		"Expiration:", humanStatus(cs, ft.ExpirationTime()),
+		"Stitches", strings.Join(stitches, cs.Link.Sprint(" >>> ")),
+		"hops", fmt.Sprint(ft.NumberOfASes()),
+	), " ")
+}

--- a/go/pkg/scioncolibrisubcmd/config.go
+++ b/go/pkg/scioncolibrisubcmd/config.go
@@ -1,0 +1,84 @@
+// Copyright 2021 Anapaya Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package colibrisubcmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
+// Config configures the colibri subcommand.
+type Config struct {
+	// Daemon configures a specific SCION Deamon address.
+	Daemon string
+	// MaxStitRsvs configures the maximum number of displayed stitchable reservations.
+	MaxStitRsvs int
+	// MaxFullTrips configures the maximum number of displayed full trips.
+	MaxFullTrips int
+}
+
+// ColorScheme allows customizing the path coloring.
+type ColorScheme struct {
+	Header *color.Color
+	Keys   *color.Color
+	Values *color.Color
+	Type   *color.Color
+	Link   *color.Color
+	Intf   *color.Color
+	Good   *color.Color
+	Bad    *color.Color
+}
+
+func DefaultColorScheme(disable bool) ColorScheme {
+	if disable {
+		noColor := color.New()
+		return ColorScheme{
+			Header: noColor,
+			Keys:   noColor,
+			Values: noColor,
+			Type:   noColor,
+			Link:   noColor,
+			Intf:   noColor,
+			Good:   noColor,
+			Bad:    noColor,
+		}
+	}
+	return ColorScheme{
+		Header: color.New(color.FgHiBlack),
+		Keys:   color.New(color.FgHiCyan),
+		Values: color.New(),
+		Type:   color.New(color.FgYellow, color.Italic),
+		Link:   color.New(color.FgHiMagenta),
+		Intf:   color.New(color.FgYellow),
+		Good:   color.New(color.FgGreen),
+		Bad:    color.New(color.FgRed),
+	}
+}
+
+func (cs ColorScheme) KeyValue(k, v string) string {
+	return fmt.Sprintf("%s: %s", cs.Keys.Sprintf(k), cs.Values.Sprintf(v))
+}
+
+func (cs ColorScheme) KeyValues(kv ...string) []string {
+	if len(kv)%2 != 0 {
+		panic("KeyValues expects even number of parameters")
+	}
+	entries := make([]string, 0, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		entries = append(entries, cs.KeyValue(kv[i], kv[i+1]))
+	}
+	return entries
+}

--- a/go/scion/BUILD.bazel
+++ b/go/scion/BUILD.bazel
@@ -4,6 +4,7 @@ load("//:scion.bzl", "scion_go_binary")
 go_library(
     name = "go_default_library",
     srcs = [
+        "colibri.go",
         "observability.go",
         "ping.go",
         "scion.go",
@@ -27,6 +28,7 @@ go_library(
         "//go/pkg/app/path:go_default_library",
         "//go/pkg/command:go_default_library",
         "//go/pkg/ping:go_default_library",
+        "//go/pkg/scioncolibrisubcmd:go_default_library",
         "//go/pkg/showpaths:go_default_library",
         "//go/pkg/traceroute:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",

--- a/go/scion/colibri.go
+++ b/go/scion/colibri.go
@@ -1,0 +1,128 @@
+// Copyright 2021 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/scionproto/scion/go/lib/addr"
+	"github.com/scionproto/scion/go/lib/daemon"
+	"github.com/scionproto/scion/go/lib/serrors"
+	"github.com/scionproto/scion/go/lib/tracing"
+	"github.com/scionproto/scion/go/pkg/app"
+	colsubcmd "github.com/scionproto/scion/go/pkg/scioncolibrisubcmd"
+)
+
+func newColibri(pather CommandPather) *cobra.Command {
+	var flags struct {
+		// cfg      showpaths.Config
+		timeout  time.Duration
+		cfg      colsubcmd.Config
+		json     bool
+		logLevel string
+		noColor  bool
+		tracer   string
+	}
+
+	v := viper.NewWithOptions(
+		viper.EnvKeyReplacer(strings.NewReplacer("SCIOND", "DAEMON", "LOCAL", "LOCAL_ADDR")),
+	)
+
+	var cmd = &cobra.Command{
+		Use:     "colibri",
+		Short:   "Display segment reservations from local to destination AS",
+		Aliases: []string{"co"},
+		Args:    cobra.ExactArgs(1),
+		Example: fmt.Sprintf(`  %[1]s colibri 1-ff00:0:110
+  %[1]s colibri 1-ff00:0:110 --local 127.0.0.55 --json`,
+			pather.CommandPath()),
+		Long: `'colibri' lists available segment reservations between the local
+and the specified SCION ASes.
+
+'colibri' can be instructed to output the paths as json using the the --json flag.
+
+If no segment reservation is found and json output is not enabled,
+colibri will exit with code 1.
+On other errors, colibri will exit with code 2.
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// flags.cfg.Defaults()
+
+			v.SetEnvPrefix("scion")
+			if err := v.BindPFlags(cmd.Flags()); err != nil {
+				return serrors.WrapStr("binding flags", err)
+			}
+			v.AutomaticEnv()
+			dst, err := addr.IAFromString(args[0])
+			if err != nil {
+				return serrors.WrapStr("invalid destination ISD-AS", err)
+			}
+			if err := app.SetupLog(flags.logLevel); err != nil {
+				return serrors.WrapStr("setting up logging", err)
+			}
+			closer, err := setupTracer("colibri", flags.tracer)
+			if err != nil {
+				return serrors.WrapStr("setting up tracing", err)
+			}
+			defer closer()
+
+			flags.cfg.Daemon = v.GetString("sciond")
+
+			cmd.SilenceUsage = true
+
+			span, traceCtx := tracing.CtxWith(context.Background(), "run")
+			span.SetTag("dst.isd_as", dst)
+			defer span.Finish()
+
+			ctx, cancel := context.WithTimeout(traceCtx, flags.timeout)
+			defer cancel()
+			res, err := colsubcmd.Run(ctx, dst, flags.cfg)
+			if err != nil {
+				return err
+			}
+
+			if flags.json {
+				return res.JSON(os.Stdout)
+			}
+			if res.ComputedFullTrips == 0 {
+				return app.WithExitCode(serrors.New("no reservation found"), 1)
+			}
+			res.Human(os.Stdout, !flags.noColor)
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.cfg.Daemon, "sciond",
+		daemon.DefaultAPIAddress, "SCION Deamon address")
+	cmd.Flags().DurationVar(&flags.timeout, "timeout", 5*time.Second, "Timeout")
+	cmd.Flags().IntVarP(&flags.cfg.MaxStitRsvs, "maxstitches", "t", 10,
+		"Maximum number of segment stitches that are displayed")
+	cmd.Flags().IntVarP(&flags.cfg.MaxFullTrips, "maxtrips", "m", 10,
+		"Maximum number of full trips that are displayed")
+	cmd.Flags().BoolVarP(&flags.json, "json", "j", false,
+		"Write the output as machine readable json")
+	cmd.Flags().BoolVar(&flags.noColor, "no-color", false, "disable colored output")
+	cmd.Flags().StringVar(&flags.logLevel, "log.level", "", app.LogLevelUsage)
+	cmd.Flags().StringVar(&flags.tracer, "tracing.agent", "", "Tracing agent address")
+	return cmd
+}

--- a/go/scion/scion.go
+++ b/go/scion/scion.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Anapaya Systems
+// Copyright 2021 ETH Zurich, Anapaya Systems
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ func main() {
 		newPing(cmd),
 		newShowpaths(cmd),
 		newTraceroute(cmd),
+		newColibri(cmd),
 	)
 
 	if err := cmd.Execute(); err != nil {


### PR DESCRIPTION
Add a subcommand to the scion application that displays reservations.
The command reports segment reservations from src to dst, and
valid stitched full trips.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/50)
<!-- Reviewable:end -->
