### PR TITLE
topology: make redemption service start after cs

### DIFF
--- a/docker/BUILD.bazel
+++ b/docker/BUILD.bazel
@@ -38,6 +38,7 @@ scion_app_image(
 scion_app_image(
     name = "control",
     src = "//control/cmd/control",
+    extra_srcs = ["//tools/http_ready:http_ready"],
     cmd = [
         "--config",
         "/etc/scion/cs.toml",

--- a/docker/scion_app.bzl
+++ b/docker/scion_app.bzl
@@ -48,10 +48,13 @@ def scion_app_base():
 #
 # Load the image into docker with
 #   bazel run //path:name.load
-def scion_app_image(name, src, entrypoint, appdir = "/app", workdir = "/share", cmd = None, caps = None, caps_binary = None):
+def scion_app_image(name, src, entrypoint, appdir = "/app", workdir = "/share", cmd = None, caps = None, caps_binary = None, extra_srcs = None):
+    srcs = [src]
+    if extra_srcs:
+        srcs += extra_srcs
     pkg_tar(
         name = "%s_docker_files" % name,
-        srcs = [src],
+        srcs = srcs,
         package_dir = appdir,
         mode = "0755",
     )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -4,6 +4,7 @@ load("@scion_python_deps//:requirements.bzl", "requirement")
 
 exports_files([
     "gzip_exec_interp",
+    "wait_http_ready.py",
 ])
 
 sh_binary(

--- a/tools/http_ready/BUILD.bazel
+++ b/tools/http_ready/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library")
+load("//:scion.bzl", "scion_go_binary")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/scionproto/scion/tools/http_ready",
+    visibility = ["//visibility:private"],
+)
+
+scion_go_binary(
+    name = "http_ready",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/http_ready/main.go
+++ b/tools/http_ready/main.go
@@ -1,0 +1,47 @@
+// Copyright 2026 ETH Zurich
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	url := flag.String("url", "", "HTTP endpoint to probe")
+	timeout := flag.Duration("timeout", 2*time.Second, "request timeout")
+	flag.Parse()
+
+	if *url == "" {
+		fmt.Fprintln(os.Stderr, "missing --url")
+		os.Exit(2)
+	}
+
+	client := &http.Client{Timeout: *timeout}
+	resp, err := client.Get(*url)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		fmt.Fprintf(os.Stderr, "unexpected status: %s\n", resp.Status)
+		os.Exit(1)
+	}
+}

--- a/tools/topology/common.py
+++ b/tools/topology/common.py
@@ -117,6 +117,10 @@ def join_host_port(host: str, port: int) -> str:
     return '[{}]:{}'.format(host, port)
 
 
+def http_url(addr: str, path: str) -> str:
+    return "http://{}{}".format(addr, path)
+
+
 def sciond_ip(docker, topo_id, networks: Mapping[IPNetwork,
                                                  NetworkDescription]):
     for net_desc in networks.values():

--- a/tools/topology/docker.py
+++ b/tools/topology/docker.py
@@ -25,6 +25,8 @@ from topology.common import (
     ArgsTopoDicts,
     docker_host,
     docker_image,
+    http_url,
+    prom_addr,
     sciond_name,
 )
 from topology.docker_utils import DockerUtilsGenArgs, DockerUtilsGenerator
@@ -164,7 +166,7 @@ class DockerGenerator(object):
             self.dc_conf['services'][k] = entry
 
     def _control_service_conf(self, topo_id, topo, base):
-        for k in topo.get("control_service", {}).keys():
+        for k, elem in topo.get("control_service", {}).items():
             entry = {
                 'image':
                 docker_image(self.args, 'control'),
@@ -177,7 +179,21 @@ class DockerGenerator(object):
                     self._cache_vol(),
                     '%s:/etc/scion:ro' % base,
                 ],
-                'command': ['--config', '/etc/scion/%s.toml' % k]
+                'command': ['--config', '/etc/scion/%s.toml' % k],
+                'healthcheck': {
+                    'test': [
+                        'CMD',
+                        '/app/http_ready',
+                        '--url',
+                        http_url(prom_addr(elem['addr'], 30452), '/metrics'),
+                        '--timeout',
+                        '2s',
+                    ],
+                    'interval': '1s',
+                    'timeout': '3s',
+                    'retries': 60,
+                    'start_period': '1s',
+                },
             }
             self.dc_conf['services'][k] = entry
 
@@ -189,7 +205,11 @@ class DockerGenerator(object):
             entry = {
                 'image':
                 docker_image(self.args, 'hummingbird'),
-                'depends_on': ['disp_%s' % k],
+                'depends_on': {
+                    k: {
+                        'condition': 'service_healthy',
+                    },
+                },
                 'network_mode':
                 'service:disp_%s' % k,
                 'user':

--- a/tools/topology/supervisor.py
+++ b/tools/topology/supervisor.py
@@ -29,6 +29,8 @@ from topology.common import (
     DISP_CONFIG_NAME,
     HBIRD_CONFIG_NAME,
     SD_CONFIG_NAME,
+    http_url,
+    prom_addr,
 )
 
 SUPERVISOR_CONF = 'supervisord.conf'
@@ -101,10 +103,27 @@ class SupervisorGenerator(object):
 
     def _hummingbird_entries(self, topo_id, topo, base):
         entries = []
-        if not topo.get("control_service", {}):
+        control_services = topo.get("control_service", {})
+        if not control_services:
+            return entries
+        cs_elem = None
+        for cs_id, elem in control_services.items():
+            if cs_id.endswith("-1"):
+                cs_elem = elem
+                break
+        if cs_elem is None:
             return entries
         name = "hbird%s" % topo_id.file_fmt()
         cmd_args = [
+            "python3",
+            "tools/wait_http_ready.py",
+            "--url",
+            http_url(prom_addr(cs_elem["addr"], 30452), "/metrics"),
+            "--timeout",
+            "60",
+            "--interval",
+            "1",
+            "--",
             "bin/hummingbird", "--config",
             os.path.join(base, HBIRD_CONFIG_NAME),
         ]

--- a/tools/wait_http_ready.py
+++ b/tools/wait_http_ready.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 ETH Zurich
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def ready(url: str, timeout: float) -> bool:
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return 200 <= response.status < 300
+    except (urllib.error.URLError, TimeoutError):
+        return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Wait for an HTTP endpoint to become ready.")
+    parser.add_argument("--url", required=True, help="Endpoint to poll.")
+    parser.add_argument("--timeout", type=float, default=60.0, help="Maximum wait in seconds.")
+    parser.add_argument("--interval", type=float, default=1.0, help="Retry interval in seconds.")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to execute after readiness.")
+    args = parser.parse_args()
+
+    command = args.command
+    if command and command[0] == "--":
+        command = command[1:]
+    if not command:
+        parser.error("missing command to execute")
+
+    deadline = time.monotonic() + args.timeout
+    while time.monotonic() < deadline:
+        if ready(args.url, min(args.interval, 2.0)):
+            os.execvp(command[0], command)
+        time.sleep(args.interval)
+
+    print(f"Timed out waiting for {args.url}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Check readiness of CS and only then start the redemption service. Fix both supervisor and docker topologies.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/59)
<!-- Reviewable:end -->
