### PR TITLE
hummingbird: router metrics

### DIFF
--- a/acceptance/router_priority/test.py
+++ b/acceptance/router_priority/test.py
@@ -51,6 +51,10 @@ def measure_br(url: str):
             "total": 0,
             "interface": defaultdict(int),
         },
+        "router_priority_forwarded_pkts":{
+            "total": 0,
+            "interface": defaultdict(int),
+        },
     }
     text = requests.get(url).text
     for family in text_string_to_metric_families(text):
@@ -134,6 +138,19 @@ class Test(base.TestTopogen):
             metrics_before["router_dropped_pkts"]["reason"]["busy_forwarder"]
         if busy_fwd == 0:
             print(f"Insufficient load: no packet drop occurred.")
+            sys.exit(1)
+        bfd_sent_delta = metrics_after["router_bfd_sent_packets"]["total"] -\
+            metrics_before["router_bfd_sent_packets"]["total"]
+        print(f"BFD sent packets delta: {bfd_sent_delta}")
+        prio_fwd = metrics_after["router_priority_forwarded_pkts"]["total"] -\
+            metrics_before["router_priority_forwarded_pkts"]["total"]
+        print(f"Priority-forwarded packets delta: {prio_fwd}")
+        if prio_fwd <= 0:
+            print("Expected priority-forwarded packets to increase, but it did not.")
+            sys.exit(1)
+        if prio_fwd < bfd_sent_delta:
+            print("Priority-forwarded packets delta is lower than BFD sent packets delta.")
+            print(f"prio_fwd={prio_fwd}, bfd_sent_delta={bfd_sent_delta}")
             sys.exit(1)
         print(f"router metrics follow.\n"
             f"Before:\n-----8<-----\n{metrics_before}\n-----8<-----\n"

--- a/doc/manuals/router/metrics.rst
+++ b/doc/manuals/router/metrics.rst
@@ -166,6 +166,18 @@ to expired reservations.
 
 **Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
 
+Hummingbird token bucket demotions total
+----------------------------------------
+
+**Name**: ``router_humm_demoted_tokenbucket_total``
+
+**Type**: Counter
+
+**Description**: Total number of Hummingbird packets demoted to best-effort due
+to token bucket checks.
+
+**Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
+
 Service instance count
 ----------------------
 

--- a/doc/manuals/router/metrics.rst
+++ b/doc/manuals/router/metrics.rst
@@ -142,6 +142,30 @@ fields.
 
 **Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
 
+Hummingbird freshness demotions total
+-------------------------------------
+
+**Name**: ``router_humm_demoted_freshness_total``
+
+**Type**: Counter
+
+**Description**: Total number of Hummingbird packets demoted to best-effort due
+to freshness checks.
+
+**Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
+
+Hummingbird expiration demotions total
+--------------------------------------
+
+**Name**: ``router_humm_demoted_expired_total``
+
+**Type**: Counter
+
+**Description**: Total number of Hummingbird packets demoted to best-effort due
+to expired reservations.
+
+**Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
+
 Service instance count
 ----------------------
 

--- a/doc/manuals/router/metrics.rst
+++ b/doc/manuals/router/metrics.rst
@@ -130,6 +130,18 @@ processor.
 
 **Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
 
+Hummingbird flyover packets total
+---------------------------------
+
+**Name**: ``router_humm_flyover_pkts_total``
+
+**Type**: Counter
+
+**Description**: Total number of parsed Hummingbird packets with flyover hop
+fields.
+
+**Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
+
 Service instance count
 ----------------------
 

--- a/doc/manuals/router/metrics.rst
+++ b/doc/manuals/router/metrics.rst
@@ -70,6 +70,19 @@ This metric reports the number of packets that were dropped because of errors.
 
 **Labels**: ``interface``, ``isd_as`` and ``neighbor_isd_as``.
 
+Priority forwarded packets total
+--------------------------------
+
+**Name**: ``router_priority_forwarded_pkts_total``
+
+**Type**: Counter
+
+**Description**: Total number of priority packets successfully forwarded by the
+router.
+
+**Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
+
+
 BFD state changes (inter-AS)
 ----------------------------
 

--- a/doc/manuals/router/metrics.rst
+++ b/doc/manuals/router/metrics.rst
@@ -57,6 +57,7 @@ local system (if any) are not counted in this number.
 
 **Labels**: ``interface``, ``isd_as`` and ``neighbor_isd_as``.
 
+
 Dropped packets total
 ---------------------
 
@@ -116,6 +117,18 @@ BFD packets sent/received (intra-AS)
 router in the local AS.
 
 **Labels**: ``sibling`` and ``isd_as``.
+
+Hummingbird packets processed total
+-----------------------------------
+
+**Name**: ``router_humm_processed_pkts_total``
+
+**Type**: Counter
+
+**Description**: Total number of Hummingbird packets received by the router
+processor.
+
+**Labels**: ``interface``, ``isd_as``, ``neighbor_isd_as`` and ``sizeclass``.
 
 Service instance count
 ----------------------

--- a/pkg/snet/squic/hummingbird_live_test.go
+++ b/pkg/snet/squic/hummingbird_live_test.go
@@ -15,10 +15,15 @@
 package squic_test
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +39,13 @@ const (
 	tinyClientListenAddr = "1-ff00:0:112,[fd00:f00d:cafe::7f00:c]:0"
 	tinyServerRemoteAddr = "1-ff00:0:111,127.0.0.20:12345"
 )
+
+var tinyBRMetricsEndpoints = []string{
+	"http://127.0.0.9:30442/metrics",
+	"http://127.0.0.10:30442/metrics",
+	"http://127.0.0.17:30442/metrics",
+	"http://[fd00:f00d:cafe::7f00:9]:30442/metrics",
+}
 
 // TestQUICOverHummingbirdTinyTopology verifies that a QUIC handshake plus a
 // stream exchange succeeds when the client sends over a Hummingbird reservation
@@ -83,6 +95,73 @@ func TestQUICOverHummingbirdTinyTopology(t *testing.T) {
 	require.NoError(t, <-serverErr)
 }
 
+// TestQUICOverHummingbirdTinyTopologyTokenBucketDemotion verifies that QUIC
+// still succeeds when the reservation bandwidth is intentionally tiny, causing
+// routers to demote packets to best-effort via token bucket checks.
+func TestQUICOverHummingbirdTinyTopologyTokenBucketDemotion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping live tiny-topology test in short mode")
+	}
+	if os.Getenv("SCION_RUN_LIVE_TESTS") == "" {
+		t.Skip("set SCION_RUN_LIVE_TESTS=1 to run live tiny-topology tests")
+	}
+
+	before, err := scrapeHummCounterTotals(tinyBRMetricsEndpoints)
+	require.NoError(t, err)
+
+	keysRoot := requireTinyTopologyAssets(t)
+	serverLocal, err := hummingbirdtest.MustParseUDPAddr(tinyServerListenAddr)
+	require.NoError(t, err)
+	clientLocal, err := hummingbirdtest.MustParseUDPAddr(tinyClientListenAddr)
+	require.NoError(t, err)
+	serverRemote, err := hummingbirdtest.MustParseUDPAddr(tinyServerRemoteAddr)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- hummingbirdtest.RunServer(
+			ctx,
+			tinyServerDaemonAddr,
+			serverLocal,
+			clientLocal.IA,
+			t.Logf,
+		)
+	}()
+
+	params := hummingbirdtest.DefaultReservationParams()
+	// Intentionally tiny so payload quickly exceeds token bucket and gets demoted.
+	params.Bandwidth = 1
+	err = hummingbirdtest.RunClientWithParams(
+		ctx,
+		tinyClientDaemonAddr,
+		clientLocal,
+		serverRemote,
+		keysRoot,
+		params,
+		t.Logf,
+	)
+	require.NoErrorf(t, err,
+		"QUIC dial timed out or failed; demoted packets should still complete over best-effort")
+
+	require.NoError(t, <-serverErr)
+
+	after, err := scrapeHummCounterTotals(tinyBRMetricsEndpoints)
+	require.NoError(t, err)
+
+	hummCounter := deltaCounter(after, before, "router_humm_processed_pkts_total")
+	flyoverCounter := deltaCounter(after, before, "router_humm_flyover_pkts_total")
+	demotedCounter := deltaCounter(after, before, "router_humm_demoted_tokenbucket_total")
+	t.Logf("total hummingbird packets: %f", hummCounter)
+	t.Logf("total flyover packets: %f", flyoverCounter)
+	t.Logf("total demotions: %f", demotedCounter)
+	require.Greater(t, hummCounter, float64(0))
+	require.Greater(t, flyoverCounter, float64(0))
+	require.Greater(t, demotedCounter, float64(0))
+}
+
 func requireTinyTopologyAssets(t *testing.T) string {
 	t.Helper()
 
@@ -99,4 +178,61 @@ func requireRepoRoot(t *testing.T) string {
 	_, file, _, ok := runtime.Caller(0)
 	require.True(t, ok, "resolve current file path")
 	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+}
+
+func scrapeHummCounterTotals(endpoints []string) (map[string]float64, error) {
+	totals := map[string]float64{
+		"router_humm_processed_pkts_total":      0,
+		"router_humm_flyover_pkts_total":        0,
+		"router_humm_demoted_freshness_total":   0,
+		"router_humm_demoted_expired_total":     0,
+		"router_humm_demoted_tokenbucket_total": 0,
+	}
+	client := &http.Client{Timeout: 3 * time.Second}
+
+	for _, endpoint := range endpoints {
+		resp, err := client.Get(endpoint)
+		if err != nil {
+			return nil, fmt.Errorf("fetching %s: %w", endpoint, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("fetching %s: status %s", endpoint, resp.Status)
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "router_humm_") || strings.HasPrefix(line, "#") {
+				continue
+			}
+			space := strings.LastIndexByte(line, ' ')
+			if space <= 0 || space == len(line)-1 {
+				continue
+			}
+			namePart := line[:space]
+			metricName := namePart
+			if brace := strings.IndexByte(namePart, '{'); brace >= 0 {
+				metricName = namePart[:brace]
+			}
+			if _, ok := totals[metricName]; !ok {
+				continue
+			}
+			v, err := strconv.ParseFloat(strings.TrimSpace(line[space+1:]), 64)
+			if err != nil {
+				continue
+			}
+			totals[metricName] += v
+		}
+		if err := scanner.Err(); err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("reading %s: %w", endpoint, err)
+		}
+		_ = resp.Body.Close()
+	}
+	return totals, nil
+}
+
+func deltaCounter(after, before map[string]float64, metric string) float64 {
+	return after[metric] - before[metric]
 }

--- a/pkg/snet/squic/hummingbirdtest/helpers.go
+++ b/pkg/snet/squic/hummingbirdtest/helpers.go
@@ -50,7 +50,7 @@ const (
 	// HbirdTestResID is the synthetic reservation ID used by the tests.
 	HbirdTestResID = uint32(1)
 	// HbirdTestBandwidth is the synthetic bandwidth class used by the tests.
-	HbirdTestBandwidth = uint16(2)
+	HbirdTestBandwidth = uint16(1024 - 1)
 	// HbirdTestDuration is the reservation lifetime in seconds.
 	HbirdTestDuration = uint16(9)
 	// HbirdTestStartOffset backdates the reservation slightly so it is already
@@ -62,6 +62,26 @@ const (
 	// QUICTestMessageReply is the fixed server response for the round trip.
 	QUICTestMessageReply = "pong over scion"
 )
+
+// ReservationParams configures synthetic Hummingbird reservation values used by
+// live tests.
+type ReservationParams struct {
+	ResID       uint32
+	Bandwidth   uint16
+	Duration    uint16
+	StartOffset time.Duration
+}
+
+// DefaultReservationParams returns the baseline reservation used by existing
+// Hummingbird live tests.
+func DefaultReservationParams() ReservationParams {
+	return ReservationParams{
+		ResID:       HbirdTestResID,
+		Bandwidth:   HbirdTestBandwidth,
+		Duration:    HbirdTestDuration,
+		StartOffset: HbirdTestStartOffset,
+	}
+}
 
 // QUICTestMessageClient is the fixed client payload used by the round-trip
 // tests. It is kept at or above 20 KiB so the exchange exercises multiple
@@ -219,11 +239,34 @@ func BuildHummingbirdRemote(
 	keysRoot string,
 	log Logger,
 ) (*snet.UDPAddr, error) {
+	return BuildHummingbirdRemoteWithParams(
+		ctx,
+		conn,
+		clientLocal,
+		serverRemote,
+		keysRoot,
+		DefaultReservationParams(),
+		log,
+	)
+}
+
+// BuildHummingbirdRemoteWithParams turns a plain remote address into one that
+// carries a Hummingbird reservation path and the matching next hop with
+// caller-provided reservation parameters.
+func BuildHummingbirdRemoteWithParams(
+	ctx context.Context,
+	conn daemon.Connector,
+	clientLocal *snet.UDPAddr,
+	serverRemote *snet.UDPAddr,
+	keysRoot string,
+	params ReservationParams,
+	log Logger,
+) (*snet.UDPAddr, error) {
 	basePath, err := BasePath(ctx, conn, clientLocal.IA, serverRemote.IA, log)
 	if err != nil {
 		return nil, err
 	}
-	reservation, err := NewHummingbirdReservation(basePath, keysRoot, time.Now(), log)
+	reservation, err := NewHummingbirdReservationWithParams(basePath, keysRoot, time.Now(), params, log)
 	if err != nil {
 		return nil, err
 	}
@@ -253,12 +296,25 @@ func NewHummingbirdReservation(
 	now time.Time,
 	log Logger,
 ) (snet.DataplanePath, error) {
+	return NewHummingbirdReservationWithParams(basePath, keysRoot, now, DefaultReservationParams(), log)
+}
+
+// NewHummingbirdReservationWithParams derives one flyover reservation per hop
+// using caller-provided reservation parameters and wraps them into a reservation
+// dataplane path.
+func NewHummingbirdReservationWithParams(
+	basePath snet.Path,
+	keysRoot string,
+	now time.Time,
+	params ReservationParams,
+	log Logger,
+) (snet.DataplanePath, error) {
 	baseHops := snetpath.InterfacesToBaseHops(basePath.Metadata().Interfaces)
 	if len(baseHops) == 0 {
 		return nil, serrors.New("base path does not contain any hops")
 	}
 
-	startTime := uint32(now.Add(HbirdTestStartOffset).Unix())
+	startTime := uint32(now.Add(params.StartOffset).Unix())
 	aesByIA := make(map[addr.IA]cipher.Block)
 	buffer := make([]byte, hummlib.AkBufferSize)
 	flyovers := make([]*snetpath.Hop, 0, len(baseHops))
@@ -279,29 +335,29 @@ func NewHummingbirdReservation(
 		// reservation so the routers can validate every flyover hop.
 		akRaw := hummlib.DeriveAuthKey(
 			block,
-			HbirdTestResID,
-			HbirdTestBandwidth,
+			params.ResID,
+			params.Bandwidth,
 			baseHop.Ingress,
 			baseHop.Egress,
 			startTime,
-			HbirdTestDuration,
+			params.Duration,
 			buffer,
 		)
 		var ak [hummlib.AkBufferSize]byte
 		copy(ak[:], akRaw)
 		if log != nil {
 			log("reservation inputs ia=%s in=%d eg=%d res_id=%d bw=%d start=%d dur=%d ak=%s",
-				baseHop.IA, baseHop.Ingress, baseHop.Egress, HbirdTestResID,
-				HbirdTestBandwidth, startTime, HbirdTestDuration, hex.EncodeToString(ak[:]))
+				baseHop.IA, baseHop.Ingress, baseHop.Egress, params.ResID,
+				params.Bandwidth, startTime, params.Duration, hex.EncodeToString(ak[:]))
 		}
 		flyovers = append(flyovers, &snetpath.Hop{
 			BaseHop: baseHop,
 			Flyover: &snetpath.FlyoverData{
-				ResID:     HbirdTestResID,
+				ResID:     params.ResID,
 				Ak:        ak,
-				Bw:        HbirdTestBandwidth,
+				Bw:        params.Bandwidth,
 				StartTime: startTime,
-				Duration:  HbirdTestDuration,
+				Duration:  params.Duration,
 			},
 		})
 	}
@@ -480,6 +536,28 @@ func RunClient(
 	keysRoot string,
 	log Logger,
 ) error {
+	return RunClientWithParams(
+		ctx,
+		daemonAddr,
+		localAddr,
+		remoteAddr,
+		keysRoot,
+		DefaultReservationParams(),
+		log,
+	)
+}
+
+// RunClientWithParams runs the client side with caller-provided reservation
+// parameters for Hummingbird path construction.
+func RunClientWithParams(
+	ctx context.Context,
+	daemonAddr string,
+	localAddr *snet.UDPAddr,
+	remoteAddr *snet.UDPAddr,
+	keysRoot string,
+	params ReservationParams,
+	log Logger,
+) error {
 	clientDaemon, err := ConnectDaemon(ctx, daemonAddr)
 	if err != nil {
 		return err
@@ -496,7 +574,8 @@ func RunClient(
 	}
 	defer clientConn.Close()
 
-	remote, err := BuildHummingbirdRemote(ctx, clientDaemon, localAddr, remoteAddr, keysRoot, log)
+	remote, err := BuildHummingbirdRemoteWithParams(
+		ctx, clientDaemon, localAddr, remoteAddr, keysRoot, params, log)
 	if err != nil {
 		return err
 	}

--- a/router/dataplane_hbird.go
+++ b/router/dataplane_hbird.go
@@ -75,6 +75,8 @@ func (p *scionPacketProcessor) parseHbirdPath() disposition {
 	}
 	if p.flyoverField.Flyover {
 		p.pkt.PriorityLabel = pr.WithPriority
+		sc := ClassOfSize(len(p.pkt.RawPacket))
+		p.pkt.Link.Metrics()[sc].HummFlyoverPackets.Inc()
 	}
 
 	return pForward
@@ -363,7 +365,7 @@ func (p *scionPacketProcessor) validatePathMetaTimestamp() {
 		time.Duration(p.hbirdPath.PathMeta.HighResTS>>22) * time.Millisecond)
 	// TODO: make a configurable value instead of using a flat 1 seconds
 	if time.Until(timestamp).Abs() > time.Duration(1)*time.Second {
-		// Forward with best-effort is timestamp is too old.
+		// Forward with best-effort if timestamp is too old.
 		p.pkt.PriorityLabel = pr.WithBestEffort
 	}
 }
@@ -636,10 +638,8 @@ func (p *scionPacketProcessor) processHbirdEgress() disposition {
 // func (p *scionPacketProcessor) processHummingbird() (processResult, error) {
 func (p *scionPacketProcessor) processHummingbird() disposition {
 	// Increment the counter of received Hummingbird packets.
-	if m := p.pkt.Link.Metrics(); m != nil {
-		sc := ClassOfSize(len(p.pkt.RawPacket))
-		m[sc].HummProcessedPackets.Inc()
-	}
+	sc := ClassOfSize(len(p.pkt.RawPacket))
+	p.pkt.Link.Metrics()[sc].HummProcessedPackets.Inc()
 
 	var ok bool
 	p.hbirdPath, ok = p.scionLayer.Path.(*hummingbird.Raw)
@@ -647,13 +647,14 @@ func (p *scionPacketProcessor) processHummingbird() disposition {
 		// TODO(lukedirtwalker) parameter problem invalid path?
 		return errorDiscard("error", errMalformedPath)
 	}
+
 	if disp := p.parseHbirdPath(); disp != pForward {
 		return disp
 	}
 	if disp := p.determinePeerHbird(); disp != pForward {
 		return disp
 	}
-	// deleteme uncomment
+
 	if disp := p.validateHopExpiryHbird(); disp != pForward {
 		return disp
 	}
@@ -679,7 +680,7 @@ func (p *scionPacketProcessor) processHummingbird() disposition {
 }
 
 func (p *scionPacketProcessor) processHBIRDFlyover() disposition {
-	// deleteme uncomment
+
 	if disp := p.validateReservationExpiry(); disp != pForward {
 		return disp
 	}

--- a/router/dataplane_hbird.go
+++ b/router/dataplane_hbird.go
@@ -635,6 +635,12 @@ func (p *scionPacketProcessor) processHbirdEgress() disposition {
 
 // func (p *scionPacketProcessor) processHummingbird() (processResult, error) {
 func (p *scionPacketProcessor) processHummingbird() disposition {
+	// Increment the counter of received Hummingbird packets.
+	if m := p.pkt.Link.Metrics(); m != nil {
+		sc := ClassOfSize(len(p.pkt.RawPacket))
+		m[sc].HummProcessedPackets.Inc()
+	}
+
 	var ok bool
 	p.hbirdPath, ok = p.scionLayer.Path.(*hummingbird.Raw)
 	if !ok {

--- a/router/dataplane_hbird.go
+++ b/router/dataplane_hbird.go
@@ -378,7 +378,7 @@ func (p *scionPacketProcessor) validatePathMetaTimestamp(sc sizeClass) {
 	}
 }
 
-func (p *scionPacketProcessor) checkReservationBandwidth() disposition {
+func (p *scionPacketProcessor) checkReservationBandwidth(sc sizeClass) disposition {
 	// Only check bandwidth if packet is given priority.
 	// Bandwidth check is NOT performed for late packets that have flyover but no priority.
 	if p.pkt.PriorityLabel != pr.WithPriority {
@@ -429,6 +429,7 @@ func (p *scionPacketProcessor) checkReservationBandwidth() disposition {
 		log.Debug("hummingbird packet exceeding allowed bandwidth token bucket",
 			"resID", fmt.Sprintf("%x", p.flyoverField.ResID))
 		p.pkt.PriorityLabel = pr.WithBestEffort
+		p.pkt.Link.Metrics()[sc].HummDemotedTokenBucketPkts.Inc()
 	} else {
 		log.Debug("hummingbird checking BW: packet fits into bucket")
 	}
@@ -696,7 +697,7 @@ func (p *scionPacketProcessor) processHBIRDFlyover(sc sizeClass) disposition {
 		return disp
 	}
 	p.validatePathMetaTimestamp(sc)
-	if disp := p.checkReservationBandwidth(); disp != pForward {
+	if disp := p.checkReservationBandwidth(sc); disp != pForward {
 		return disp
 	}
 	if disp := p.handleHbirdIngressRouterAlert(); disp != pForward {

--- a/router/dataplane_hbird.go
+++ b/router/dataplane_hbird.go
@@ -34,6 +34,12 @@ import (
 	"github.com/scionproto/scion/router/tokenbucket"
 )
 
+// MaxFreshnessTolerance is the allowed drift from current time for a "fresh" packet.
+// If the packet exceeds this limit (under or over), it will be best-effort.
+// This parameter heavily correlates with the allowed clock drift, and maximum path latency.
+// TODO: make a configurable value instead of using a flat 5 seconds
+const MaxFreshnessTolerance = 5 * time.Second
+
 // SetHbirdKey sets the key for the PRF function used to compute the Hummingbird Auth Key.
 func (d *dataPlane) SetHbirdKey(key []byte) error {
 	d.mtx.Lock()
@@ -58,7 +64,7 @@ func (d *dataPlane) SetHbirdKey(key []byte) error {
 	return nil
 }
 
-func (p *scionPacketProcessor) parseHbirdPath() disposition {
+func (p *scionPacketProcessor) parseHbirdPath(sc sizeClass) disposition {
 	var err error
 	if !p.hbirdPath.CurrHFIsHopStart() || !p.hbirdPath.CurrINFMatchesCurrHF() {
 		return errorDiscard("error", errMalformedPath)
@@ -75,7 +81,6 @@ func (p *scionPacketProcessor) parseHbirdPath() disposition {
 	}
 	if p.flyoverField.Flyover {
 		p.pkt.PriorityLabel = pr.WithPriority
-		sc := ClassOfSize(len(p.pkt.RawPacket))
 		p.pkt.Link.Metrics()[sc].HummFlyoverPackets.Inc()
 	}
 
@@ -136,7 +141,7 @@ func (p *scionPacketProcessor) validateHopExpiryHbird() disposition {
 	return pSlowPath
 }
 
-func (p *scionPacketProcessor) validateReservationExpiry() disposition {
+func (p *scionPacketProcessor) validateReservationExpiry(sc sizeClass) disposition {
 	startTime := util.SecsToTime(p.hbirdPath.PathMeta.BaseTS - uint32(p.flyoverField.ResStartTime))
 	endTime := startTime.Add(time.Duration(p.flyoverField.Duration) * time.Second)
 	now := time.Now()
@@ -147,6 +152,7 @@ func (p *scionPacketProcessor) validateReservationExpiry() disposition {
 		"reservation start", startTime,
 		"reservation end", endTime, "now", now)
 	p.pkt.PriorityLabel = pr.WithBestEffort
+	p.pkt.Link.Metrics()[sc].HummDemotedExpiredPkts.Inc()
 	return pForward
 }
 
@@ -358,15 +364,17 @@ func (p *scionPacketProcessor) validateHbirdTransitUnderlaySrc() disposition {
 	return pForward
 }
 
-// Verifies the PathMetaHeader timestamp is recent
-// Current implementation works with a nanosecond granularity HighResTS
-func (p *scionPacketProcessor) validatePathMetaTimestamp() {
+// Verifies the PathMetaHeader timestamp is recent.
+// Current implementation works with a millisecond granularity HighResTS.
+// If the freshness of the packet is not within 5 seconds, it will be marked as best-effort.
+func (p *scionPacketProcessor) validatePathMetaTimestamp(sc sizeClass) {
 	timestamp := util.SecsToTime(p.hbirdPath.PathMeta.BaseTS).Add(
 		time.Duration(p.hbirdPath.PathMeta.HighResTS>>22) * time.Millisecond)
-	// TODO: make a configurable value instead of using a flat 1 seconds
-	if time.Until(timestamp).Abs() > time.Duration(1)*time.Second {
+
+	if time.Until(timestamp).Abs() > MaxFreshnessTolerance {
 		// Forward with best-effort if timestamp is too old.
 		p.pkt.PriorityLabel = pr.WithBestEffort
+		p.pkt.Link.Metrics()[sc].HummDemotedFreshnessPkts.Inc()
 	}
 }
 
@@ -635,7 +643,6 @@ func (p *scionPacketProcessor) processHbirdEgress() disposition {
 	return pForward
 }
 
-// func (p *scionPacketProcessor) processHummingbird() (processResult, error) {
 func (p *scionPacketProcessor) processHummingbird() disposition {
 	// Increment the counter of received Hummingbird packets.
 	sc := ClassOfSize(len(p.pkt.RawPacket))
@@ -648,9 +655,10 @@ func (p *scionPacketProcessor) processHummingbird() disposition {
 		return errorDiscard("error", errMalformedPath)
 	}
 
-	if disp := p.parseHbirdPath(); disp != pForward {
+	if disp := p.parseHbirdPath(sc); disp != pForward {
 		return disp
 	}
+
 	if disp := p.determinePeerHbird(); disp != pForward {
 		return disp
 	}
@@ -674,20 +682,20 @@ func (p *scionPacketProcessor) processHummingbird() disposition {
 		return disp
 	}
 	if p.flyoverField.Flyover {
-		return p.processHBIRDFlyover()
+		return p.processHBIRDFlyover(sc)
 	}
 	return p.processHBIRDBestEffort()
 }
 
-func (p *scionPacketProcessor) processHBIRDFlyover() disposition {
+func (p *scionPacketProcessor) processHBIRDFlyover(sc sizeClass) disposition {
 
-	if disp := p.validateReservationExpiry(); disp != pForward {
+	if disp := p.validateReservationExpiry(sc); disp != pForward {
 		return disp
 	}
 	if disp := p.verifyHbirdFlyoverMac(); disp != pForward {
 		return disp
 	}
-	p.validatePathMetaTimestamp()
+	p.validatePathMetaTimestamp(sc)
 	if disp := p.checkReservationBandwidth(); disp != pForward {
 		return disp
 	}

--- a/router/export_test.go
+++ b/router/export_test.go
@@ -59,12 +59,13 @@ type SlowPathRequestView struct {
 
 // Implements the link interface minimally
 type MockLink struct {
-	ifID uint16
+	ifID    uint16
+	metrics *InterfaceMetrics
 }
 
 func (l *MockLink) IsUp() bool                                           { return true }
 func (l *MockLink) IfID() uint16                                         { return l.ifID }
-func (l *MockLink) Metrics() *InterfaceMetrics                           { return nil }
+func (l *MockLink) Metrics() *InterfaceMetrics                           { return l.metrics }
 func (l *MockLink) Scope() LinkScope                                     { return Internal }
 func (l *MockLink) BFDSession() *bfd.Session                             { return nil }
 func (l *MockLink) Resolve(p *Packet, host addr.Host, port uint16) error { return nil }
@@ -73,7 +74,14 @@ func (l *MockLink) SendBlocking(p *Packet)                               {}
 
 var _ Link = new(MockLink)
 
-func newMockLink(ingress uint16) Link { return &MockLink{ifID: ingress} }
+func newMockLink(ingress uint16) Link {
+	local := addr.MustParseIA("1-ff00:0:1")
+	neighbor := addr.MustParseIA("1-ff00:0:2")
+	return &MockLink{
+		ifID:    ingress,
+		metrics: newInterfaceMetrics(metrics, ingress, local, "", neighbor),
+	}
+}
 
 // NewPacket makes a mock packet. It has shortcomings which makes it unsuited for some tests: it
 // refers to a mock link that has the scope Internal in all cases, and a blank remote address.

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -35,6 +35,7 @@ type Metrics struct {
 	OutputPacketsTotal        *prometheus.CounterVec
 	ProcessedPackets          *prometheus.CounterVec
 	HummProcessedPackets      *prometheus.CounterVec
+	HummFlyoverPackets        *prometheus.CounterVec
 	DroppedPacketsTotal       *prometheus.CounterVec
 	InterfaceUp               *prometheus.GaugeVec
 	BFDInterfaceStateChanges  *prometheus.CounterVec
@@ -63,6 +64,13 @@ func NewMetrics() *Metrics {
 			prometheus.CounterOpts{
 				Name: "router_humm_processed_pkts_total",
 				Help: "Total number of Hummingbird packets received by the router processor",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
+		),
+		HummFlyoverPackets: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_humm_flyover_pkts_total",
+				Help: "Total number of parsed Hummingbird packets with a flyover",
 			},
 			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
 		),
@@ -278,6 +286,7 @@ type trafficMetrics struct {
 	DroppedPacketsBusySlowPath  prometheus.Counter
 	ProcessedPackets            prometheus.Counter
 	HummProcessedPackets        prometheus.Counter
+	HummFlyoverPackets          prometheus.Counter
 	Output                      [ttMax]outputMetrics
 }
 
@@ -315,6 +324,7 @@ func newTrafficMetrics(
 		InputPacketsTotal:    metrics.InputPacketsTotal.MustCurryWith(ifLabels).With(scLabels),
 		ProcessedPackets:     metrics.ProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
 		HummProcessedPackets: metrics.HummProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
+		HummFlyoverPackets:   metrics.HummFlyoverPackets.MustCurryWith(ifLabels).With(scLabels),
 	}
 
 	// Output metrics have the extra "trafficType" label.
@@ -350,6 +360,7 @@ func newTrafficMetrics(
 	c.DroppedPacketsBusySlowPath.Add(0)
 	c.ProcessedPackets.Add(0)
 	c.HummProcessedPackets.Add(0)
+	c.HummFlyoverPackets.Add(0)
 	return c
 }
 

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -29,27 +29,28 @@ import (
 
 // Metrics defines the data-plane metrics for the BR.
 type Metrics struct {
-	InputBytesTotal           *prometheus.CounterVec
-	OutputBytesTotal          *prometheus.CounterVec
-	InputPacketsTotal         *prometheus.CounterVec
-	OutputPacketsTotal        *prometheus.CounterVec
-	ProcessedPackets          *prometheus.CounterVec
-	DroppedPacketsTotal       *prometheus.CounterVec
-	HummProcessedPackets      *prometheus.CounterVec
-	HummFlyoverPackets        *prometheus.CounterVec
-	HummDemotedFreshnessPkts  *prometheus.CounterVec
-	HummDemotedExpiredPkts    *prometheus.CounterVec
+	InputBytesTotal            *prometheus.CounterVec
+	OutputBytesTotal           *prometheus.CounterVec
+	InputPacketsTotal          *prometheus.CounterVec
+	OutputPacketsTotal         *prometheus.CounterVec
+	ProcessedPackets           *prometheus.CounterVec
+	PriorityForwardedPackets   *prometheus.CounterVec
+	DroppedPacketsTotal        *prometheus.CounterVec
+	HummProcessedPackets       *prometheus.CounterVec
+	HummFlyoverPackets         *prometheus.CounterVec
+	HummDemotedFreshnessPkts   *prometheus.CounterVec
+	HummDemotedExpiredPkts     *prometheus.CounterVec
 	HummDemotedTokenBucketPkts *prometheus.CounterVec
-	InterfaceUp               *prometheus.GaugeVec
-	BFDInterfaceStateChanges  *prometheus.CounterVec
-	BFDPacketsSent            *prometheus.CounterVec
-	BFDPacketsReceived        *prometheus.CounterVec
-	ServiceInstanceCount      *prometheus.GaugeVec
-	ServiceInstanceChanges    *prometheus.CounterVec
-	SiblingReachable          *prometheus.GaugeVec
-	SiblingBFDPacketsSent     *prometheus.CounterVec
-	SiblingBFDPacketsReceived *prometheus.CounterVec
-	SiblingBFDStateChanges    *prometheus.CounterVec
+	InterfaceUp                *prometheus.GaugeVec
+	BFDInterfaceStateChanges   *prometheus.CounterVec
+	BFDPacketsSent             *prometheus.CounterVec
+	BFDPacketsReceived         *prometheus.CounterVec
+	ServiceInstanceCount       *prometheus.GaugeVec
+	ServiceInstanceChanges     *prometheus.CounterVec
+	SiblingReachable           *prometheus.GaugeVec
+	SiblingBFDPacketsSent      *prometheus.CounterVec
+	SiblingBFDPacketsReceived  *prometheus.CounterVec
+	SiblingBFDStateChanges     *prometheus.CounterVec
 }
 
 // NewMetrics initializes the metrics for the Border Router, and registers them with the default
@@ -60,6 +61,13 @@ func NewMetrics() *Metrics {
 			prometheus.CounterOpts{
 				Name: "router_processed_pkts_total",
 				Help: "Total number of packets processed by the processor",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
+		),
+		PriorityForwardedPackets: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_priority_forwarded_pkts_total",
+				Help: "Total number of priority packets successfully forwarded by the router",
 			},
 			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
 		),
@@ -309,6 +317,7 @@ type trafficMetrics struct {
 	DroppedPacketsBusyForwarder prometheus.Counter
 	DroppedPacketsBusySlowPath  prometheus.Counter
 	ProcessedPackets            prometheus.Counter
+	PriorityForwardedPackets    prometheus.Counter
 	HummProcessedPackets        prometheus.Counter
 	HummFlyoverPackets          prometheus.Counter
 	HummDemotedFreshnessPkts    prometheus.Counter
@@ -347,9 +356,11 @@ func newTrafficMetrics(
 	scLabels prometheus.Labels) trafficMetrics {
 
 	c := trafficMetrics{
-		InputBytesTotal:      metrics.InputBytesTotal.MustCurryWith(ifLabels).With(scLabels),
-		InputPacketsTotal:    metrics.InputPacketsTotal.MustCurryWith(ifLabels).With(scLabels),
-		ProcessedPackets:     metrics.ProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
+		InputBytesTotal:   metrics.InputBytesTotal.MustCurryWith(ifLabels).With(scLabels),
+		InputPacketsTotal: metrics.InputPacketsTotal.MustCurryWith(ifLabels).With(scLabels),
+		ProcessedPackets:  metrics.ProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
+		PriorityForwardedPackets: metrics.PriorityForwardedPackets.MustCurryWith(ifLabels).
+			With(scLabels),
 		HummProcessedPackets: metrics.HummProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
 		HummFlyoverPackets:   metrics.HummFlyoverPackets.MustCurryWith(ifLabels).With(scLabels),
 		HummDemotedFreshnessPkts: metrics.HummDemotedFreshnessPkts.MustCurryWith(ifLabels).
@@ -391,6 +402,7 @@ func newTrafficMetrics(
 	c.DroppedPacketsBusyForwarder.Add(0)
 	c.DroppedPacketsBusySlowPath.Add(0)
 	c.ProcessedPackets.Add(0)
+	c.PriorityForwardedPackets.Add(0)
 	c.HummProcessedPackets.Add(0)
 	c.HummFlyoverPackets.Add(0)
 	c.HummDemotedFreshnessPkts.Add(0)

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -34,6 +34,7 @@ type Metrics struct {
 	InputPacketsTotal         *prometheus.CounterVec
 	OutputPacketsTotal        *prometheus.CounterVec
 	ProcessedPackets          *prometheus.CounterVec
+	HummProcessedPackets      *prometheus.CounterVec
 	DroppedPacketsTotal       *prometheus.CounterVec
 	InterfaceUp               *prometheus.GaugeVec
 	BFDInterfaceStateChanges  *prometheus.CounterVec
@@ -55,6 +56,13 @@ func NewMetrics() *Metrics {
 			prometheus.CounterOpts{
 				Name: "router_processed_pkts_total",
 				Help: "Total number of packets processed by the processor",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
+		),
+		HummProcessedPackets: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_humm_processed_pkts_total",
+				Help: "Total number of Hummingbird packets received by the router processor",
 			},
 			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
 		),
@@ -269,6 +277,7 @@ type trafficMetrics struct {
 	DroppedPacketsBusyForwarder prometheus.Counter
 	DroppedPacketsBusySlowPath  prometheus.Counter
 	ProcessedPackets            prometheus.Counter
+	HummProcessedPackets        prometheus.Counter
 	Output                      [ttMax]outputMetrics
 }
 
@@ -302,9 +311,10 @@ func newTrafficMetrics(
 	scLabels prometheus.Labels) trafficMetrics {
 
 	c := trafficMetrics{
-		InputBytesTotal:   metrics.InputBytesTotal.MustCurryWith(ifLabels).With(scLabels),
-		InputPacketsTotal: metrics.InputPacketsTotal.MustCurryWith(ifLabels).With(scLabels),
-		ProcessedPackets:  metrics.ProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
+		InputBytesTotal:      metrics.InputBytesTotal.MustCurryWith(ifLabels).With(scLabels),
+		InputPacketsTotal:    metrics.InputPacketsTotal.MustCurryWith(ifLabels).With(scLabels),
+		ProcessedPackets:     metrics.ProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
+		HummProcessedPackets: metrics.HummProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
 	}
 
 	// Output metrics have the extra "trafficType" label.
@@ -339,6 +349,7 @@ func newTrafficMetrics(
 	c.DroppedPacketsBusyForwarder.Add(0)
 	c.DroppedPacketsBusySlowPath.Add(0)
 	c.ProcessedPackets.Add(0)
+	c.HummProcessedPackets.Add(0)
 	return c
 }
 

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -34,9 +34,11 @@ type Metrics struct {
 	InputPacketsTotal         *prometheus.CounterVec
 	OutputPacketsTotal        *prometheus.CounterVec
 	ProcessedPackets          *prometheus.CounterVec
+	DroppedPacketsTotal       *prometheus.CounterVec
 	HummProcessedPackets      *prometheus.CounterVec
 	HummFlyoverPackets        *prometheus.CounterVec
-	DroppedPacketsTotal       *prometheus.CounterVec
+	HummDemotedFreshnessPkts  *prometheus.CounterVec
+	HummDemotedExpiredPkts    *prometheus.CounterVec
 	InterfaceUp               *prometheus.GaugeVec
 	BFDInterfaceStateChanges  *prometheus.CounterVec
 	BFDPacketsSent            *prometheus.CounterVec
@@ -57,20 +59,6 @@ func NewMetrics() *Metrics {
 			prometheus.CounterOpts{
 				Name: "router_processed_pkts_total",
 				Help: "Total number of packets processed by the processor",
-			},
-			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
-		),
-		HummProcessedPackets: promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "router_humm_processed_pkts_total",
-				Help: "Total number of Hummingbird packets received by the router processor",
-			},
-			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
-		),
-		HummFlyoverPackets: promauto.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "router_humm_flyover_pkts_total",
-				Help: "Total number of parsed Hummingbird packets with a flyover",
 			},
 			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
 		),
@@ -108,6 +96,34 @@ func NewMetrics() *Metrics {
 				Help: "Total number of packets dropped by the router.",
 			},
 			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass", "reason"},
+		),
+		HummProcessedPackets: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_humm_processed_pkts_total",
+				Help: "Total number of Hummingbird packets received by the router processor",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
+		),
+		HummFlyoverPackets: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_humm_flyover_pkts_total",
+				Help: "Total number of parsed Hummingbird packets with a flyover",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
+		),
+		HummDemotedFreshnessPkts: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_humm_demoted_freshness_total",
+				Help: "Total number of Hummingbird packets demoted to best-effort due to freshness checks",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
+		),
+		HummDemotedExpiredPkts: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_humm_demoted_expired_total",
+				Help: "Total number of Hummingbird packets demoted to best-effort due to expired reservations",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
 		),
 		InterfaceUp: promauto.NewGaugeVec(
 			prometheus.GaugeOpts{
@@ -287,6 +303,8 @@ type trafficMetrics struct {
 	ProcessedPackets            prometheus.Counter
 	HummProcessedPackets        prometheus.Counter
 	HummFlyoverPackets          prometheus.Counter
+	HummDemotedFreshnessPkts    prometheus.Counter
+	HummDemotedExpiredPkts      prometheus.Counter
 	Output                      [ttMax]outputMetrics
 }
 
@@ -325,6 +343,9 @@ func newTrafficMetrics(
 		ProcessedPackets:     metrics.ProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
 		HummProcessedPackets: metrics.HummProcessedPackets.MustCurryWith(ifLabels).With(scLabels),
 		HummFlyoverPackets:   metrics.HummFlyoverPackets.MustCurryWith(ifLabels).With(scLabels),
+		HummDemotedFreshnessPkts: metrics.HummDemotedFreshnessPkts.MustCurryWith(ifLabels).
+			With(scLabels),
+		HummDemotedExpiredPkts: metrics.HummDemotedExpiredPkts.MustCurryWith(ifLabels).With(scLabels),
 	}
 
 	// Output metrics have the extra "trafficType" label.
@@ -361,6 +382,8 @@ func newTrafficMetrics(
 	c.ProcessedPackets.Add(0)
 	c.HummProcessedPackets.Add(0)
 	c.HummFlyoverPackets.Add(0)
+	c.HummDemotedFreshnessPkts.Add(0)
+	c.HummDemotedExpiredPkts.Add(0)
 	return c
 }
 

--- a/router/metrics.go
+++ b/router/metrics.go
@@ -39,6 +39,7 @@ type Metrics struct {
 	HummFlyoverPackets        *prometheus.CounterVec
 	HummDemotedFreshnessPkts  *prometheus.CounterVec
 	HummDemotedExpiredPkts    *prometheus.CounterVec
+	HummDemotedTokenBucketPkts *prometheus.CounterVec
 	InterfaceUp               *prometheus.GaugeVec
 	BFDInterfaceStateChanges  *prometheus.CounterVec
 	BFDPacketsSent            *prometheus.CounterVec
@@ -122,6 +123,13 @@ func NewMetrics() *Metrics {
 			prometheus.CounterOpts{
 				Name: "router_humm_demoted_expired_total",
 				Help: "Total number of Hummingbird packets demoted to best-effort due to expired reservations",
+			},
+			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
+		),
+		HummDemotedTokenBucketPkts: promauto.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "router_humm_demoted_tokenbucket_total",
+				Help: "Total number of Hummingbird packets demoted to best-effort due to token bucket checks",
 			},
 			[]string{"interface", "isd_as", "neighbor_isd_as", "sizeclass"},
 		),
@@ -305,6 +313,7 @@ type trafficMetrics struct {
 	HummFlyoverPackets          prometheus.Counter
 	HummDemotedFreshnessPkts    prometheus.Counter
 	HummDemotedExpiredPkts      prometheus.Counter
+	HummDemotedTokenBucketPkts  prometheus.Counter
 	Output                      [ttMax]outputMetrics
 }
 
@@ -346,6 +355,8 @@ func newTrafficMetrics(
 		HummDemotedFreshnessPkts: metrics.HummDemotedFreshnessPkts.MustCurryWith(ifLabels).
 			With(scLabels),
 		HummDemotedExpiredPkts: metrics.HummDemotedExpiredPkts.MustCurryWith(ifLabels).With(scLabels),
+		HummDemotedTokenBucketPkts: metrics.HummDemotedTokenBucketPkts.MustCurryWith(ifLabels).
+			With(scLabels),
 	}
 
 	// Output metrics have the extra "trafficType" label.
@@ -384,6 +395,7 @@ func newTrafficMetrics(
 	c.HummFlyoverPackets.Add(0)
 	c.HummDemotedFreshnessPkts.Add(0)
 	c.HummDemotedExpiredPkts.Add(0)
+	c.HummDemotedTokenBucketPkts.Add(0)
 	return c
 }
 

--- a/router/underlayproviders/udpip/udpip.go
+++ b/router/underlayproviders/udpip/udpip.go
@@ -443,6 +443,10 @@ func (u *udpConnection) send(batchSize int, pool router.PacketPool) {
 		router.UpdateOutputMetrics(u.metrics, iterator)
 		// Return storage for all the written packets.
 		for p := range iterator {
+			if p.PriorityLabel == pr.WithPriority {
+				sc := router.ClassOfSize(len(p.RawPacket))
+				u.metrics[sc].PriorityForwardedPackets.Inc()
+			}
 			pool.Put(p)
 		}
 		// The next packet to write is now the first one not written.

--- a/router/underlayproviders/udpip/udpip_test.go
+++ b/router/underlayproviders/udpip/udpip_test.go
@@ -18,6 +18,7 @@ package udpip
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"hash/fnv"
 	"net/netip"
 	"testing"
@@ -33,6 +34,7 @@ import (
 	"github.com/scionproto/scion/pkg/slayers"
 	"github.com/scionproto/scion/pkg/slayers/path"
 	"github.com/scionproto/scion/pkg/slayers/path/scion"
+	"github.com/scionproto/scion/router"
 )
 
 var (
@@ -317,4 +319,23 @@ func TestComputeProcIdErrorCases(t *testing.T) {
 			assert.Equal(t, tc.expectedSuccess, ok)
 		})
 	}
+}
+
+// BenchmarkClassOfSize measures the overhead of calling ClassOfSize per packet.
+// Since our udpConnection.send function calls it for every packet, this overhead should be small.
+func BenchmarkClassOfSize(b *testing.B) {
+	sizes := []int{1, 50, 100, 200, 2000, 9000}
+
+	var sink int
+	for _, sz := range sizes {
+		sz := sz
+		b.Run(fmt.Sprintf("size=%d", sz), func(b *testing.B) {
+			var sc int
+			for i := 0; i < b.N; i++ {
+				sc = int(router.ClassOfSize(sz))
+			}
+			sink = sc
+		})
+	}
+	_ = sink
 }


### PR DESCRIPTION
- [x] Add several prometheus counters to measure Hummingbird packets forwarding:
  - `router_priority_forwarded_pkts_total`: priority packets forwarded.
  - `router_humm_processed_pkts_total`: hummingbird packets processed (or _seen_).
  - `router_humm_flyover_pkts_total`: humm. packets with flyover (initially with priority).
  - `router_humm_demoted_freshness_total`: humm. packets demoted to best-effort due to unfreshness (stale timestamp).
  - `router_humm_demoted_expired_total`: demoted packets due to expired reservation.
  - `router_humm_demoted_tokenbucket_total`: demoted packets due to excessive bandwidth.

- [x] Use new prometheus metrics in `router_priority` and `squic_hummingbird` acceptance tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/62)
<!-- Reviewable:end -->
