### PR TITLE
Reply pather per source

### DIFF
--- a/pkg/snet/path/BUILD.bazel
+++ b/pkg/snet/path/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/slayers/path/onehop:go_default_library",
         "//pkg/slayers/path/scion:go_default_library",
         "//pkg/snet:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/pkg/snet/path/hummingbird.go
+++ b/pkg/snet/path/hummingbird.go
@@ -161,6 +161,23 @@ func (r *Reservation) deriveDataPlanePath(
 	}
 }
 
+// Expiry returns the earliest time at which one of this reservation's flyovers stops being
+// valid. It returns the zero Time if the reservation has no flyovers, i.e. it does not expire
+// on its own.
+func (r *Reservation) Expiry() time.Time {
+	var earliest time.Time
+	for _, h := range r.Hops {
+		if h == nil || h.Flyover == nil {
+			continue
+		}
+		end := time.Unix(int64(h.Flyover.StartTime)+int64(h.Flyover.Duration), 0)
+		if earliest.IsZero() || end.Before(earliest) {
+			earliest = end
+		}
+	}
+	return earliest
+}
+
 // ReservationModFcn is a options setting function for a reservation.
 type ReservationModFcn func(*Reservation) error
 

--- a/pkg/snet/path/hummingbird_reply_pather.go
+++ b/pkg/snet/path/hummingbird_reply_pather.go
@@ -44,6 +44,9 @@ type HummReplyPather struct {
 	mu sync.Mutex
 	// reservations maintains a Hummingbird Reservation to each source who has sent a reverse
 	// reservation to reach them. It is populated by SetState and consumed by ReplyPathTo.
+	// SetState only ever stores entries with a non-zero expiry (see reservationEntry.expiry);
+	// a reverse reservation with no flyovers is rejected before it would be cached, since it
+	// offers nothing beyond letting ReplyPathTo fall back to reversing the transport path.
 	reservations map[snet.SourceIdentifier]reservationEntry
 	// expirations is a min-heap of (source, expiry) pairs ordered by expiry time, used to
 	// evict entries from reservations once they are no longer valid. It may contain stale
@@ -52,10 +55,11 @@ type HummReplyPather struct {
 	expirations expiryHeap
 }
 
-// reservationEntry is the value type stored in HummReplyPather.reservations.
+// reservationEntry is the value type stored in HummReplyPather.reservations. expiry is always
+// non-zero: SetState never caches a reservation whose own Expiry() is zero.
 type reservationEntry struct {
 	rsv    *Reservation
-	expiry time.Time // expiration + slack. Zero if it never expires (e.g. no flyovers)
+	expiry time.Time // expiration + slack.
 }
 
 var _ snet.StatefulReplyPather = (*HummReplyPather)(nil)
@@ -86,6 +90,8 @@ func WithCleanupSlack(slack time.Duration) HummReplyPatherOption {
 	}
 }
 
+// WithClock overrides the function HummReplyPather uses to obtain the current time. It is
+// intended for testing the cleanup logic deterministically.
 func WithClock(now func() time.Time) HummReplyPatherOption {
 	return func(p *HummReplyPather) {
 		p.Now = now
@@ -113,20 +119,29 @@ func (p *HummReplyPather) SetState(sourceId snet.SourceIdentifier, pkt snet.Pack
 	}
 
 	expiry := rsv.Expiry()
-	if !expiry.IsZero() {
-		expiry = expiry.Add(p.CleanupSlack)
+	if expiry.IsZero() {
+		// No flyovers: a reversed Reservation with no flyovers offers nothing beyond
+		// reversing the transport path directly, so don't cache it. ReplyPathTo will fall
+		// back to the default reply pather, yielding a similar result.
+		// If a previously cached reservation exists for this source, remove it: this
+		// SetState call reflects the source's current reservation state, which supersedes
+		// whatever was cached before, so keeping the old entry around would only serve a
+		// now-outdated reservation until it happens to expire on its own.
+		p.mu.Lock()
+		delete(p.reservations, sourceId)
+		p.mu.Unlock()
+		return nil
 	}
+
 	entry := reservationEntry{
 		rsv:    rsv,
-		expiry: expiry,
+		expiry: expiry.Add(p.CleanupSlack),
 	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.reservations[sourceId] = entry
-	if !entry.expiry.IsZero() {
-		heap.Push(&p.expirations, expiryItem{srcId: sourceId, expiry: entry.expiry})
-	}
+	heap.Push(&p.expirations, expiryItem{srcId: sourceId, expiry: entry.expiry})
 	// Cleanup is tied to insertion rather than lookup: this is the only place the map can
 	// grow, so sweeping every globally-expired entry here (irrespective of the current
 	// source ID) bounds its size relative to how often reservations are set up, regardless

--- a/pkg/snet/path/hummingbird_reply_pather.go
+++ b/pkg/snet/path/hummingbird_reply_pather.go
@@ -15,28 +15,80 @@
 package path
 
 import (
+	"container/heap"
+	"sync"
+	"time"
+
 	"github.com/scionproto/scion/pkg/slayers"
 	"github.com/scionproto/scion/pkg/snet"
 )
 
+// DefaultCleanupSlack is the slack duration added to a cached reservation's expiry time before
+// it becomes eligible for cleanup, used unless a different value is given via WithCleanupSlack.
+const DefaultCleanupSlack = 10 * time.Second
+
+// HummReplyPather is a singleton, per-Conn, StatefulReplyPather that caches a bidirectional
+// Hummingbird Reservation for each distinct remote source (identified by the IA, IP, port
+// triplet in snet.SourceIdentifier) that has advertised reverse-reservation state. It is safe
+// for concurrent use by multiple goroutines, e.g. serving several clients over the same Conn.
 type HummReplyPather struct {
 	BackupRepyPather snet.ReplyPather // Used if no bidirectional reservation is available.
 
-	// reservations maintains a Hummingbird Reservation to each source who has sent a reverse
-	// reservation to reach them. It is populated by SetState.
-	reservations map[snet.SourceIdentifier]*Reservation
+	// Now returns the current time. Overridable for testing.
+	Now func() time.Time
 
-	// TODO clean the reservation map via a configurable callback.
+	// CleanupSlack is added to a reservation's own expiry time before that entry becomes
+	// eligible for removal from the cache, to tolerate clock skew and in-flight packets.
+	CleanupSlack time.Duration
+
+	mu sync.Mutex
+	// reservations maintains a Hummingbird Reservation to each source who has sent a reverse
+	// reservation to reach them. It is populated by SetState and consumed by ReplyPathTo.
+	reservations map[snet.SourceIdentifier]reservationEntry
+	// expirations is a min-heap of (source, expiry) pairs ordered by expiry time, used to
+	// evict entries from reservations once they are no longer valid. It may contain stale
+	// entries for a source whose cached reservation has since been replaced; those are
+	// recognized and discarded (not evicted) at cleanup time, see cleanupLocked.
+	expirations expiryHeap
+}
+
+// reservationEntry is the value type stored in HummReplyPather.reservations.
+type reservationEntry struct {
+	rsv    *Reservation
+	expiry time.Time // expiration + slack. Zero if it never expires (e.g. no flyovers)
 }
 
 var _ snet.StatefulReplyPather = (*HummReplyPather)(nil)
 
 // NewHummReplyPather returns a HummReplyPather with its backup reply pather set to a regular
 // DefaultReplyPather.
-func NewHummReplyPather() *HummReplyPather {
-	return &HummReplyPather{
+func NewHummReplyPather(opts ...HummReplyPatherOption) *HummReplyPather {
+	p := &HummReplyPather{
 		BackupRepyPather: snet.DefaultReplyPather{},
-		reservations:     make(map[snet.SourceIdentifier]*Reservation),
+		Now:              time.Now,
+		CleanupSlack:     DefaultCleanupSlack,
+		reservations:     make(map[snet.SourceIdentifier]reservationEntry),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// HummReplyPatherOption customizes a HummReplyPather returned by NewHummReplyPather.
+type HummReplyPatherOption func(*HummReplyPather)
+
+// WithCleanupSlack overrides the default slack duration added to a cached reservation's expiry
+// time before it becomes eligible for cleanup.
+func WithCleanupSlack(slack time.Duration) HummReplyPatherOption {
+	return func(p *HummReplyPather) {
+		p.CleanupSlack = slack
+	}
+}
+
+func WithClock(now func() time.Time) HummReplyPatherOption {
+	return func(p *HummReplyPather) {
+		p.Now = now
 	}
 }
 
@@ -60,28 +112,67 @@ func (p *HummReplyPather) SetState(sourceId snet.SourceIdentifier, pkt snet.Pack
 		return err
 	}
 
-	p.reservations[sourceId] = rsv
+	expiry := rsv.Expiry()
+	if !expiry.IsZero() {
+		expiry = expiry.Add(p.CleanupSlack)
+	}
+	entry := reservationEntry{
+		rsv:    rsv,
+		expiry: expiry,
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.reservations[sourceId] = entry
+	if !entry.expiry.IsZero() {
+		heap.Push(&p.expirations, expiryItem{srcId: sourceId, expiry: entry.expiry})
+	}
+	// Cleanup is tied to insertion rather than lookup: this is the only place the map can
+	// grow, so sweeping every globally-expired entry here (irrespective of the current
+	// source ID) bounds its size relative to how often reservations are set up, regardless
+	// of how often ReplyPathTo is called. A consequence is that a stale entry keeps being
+	// returned by ReplyPathTo until some future SetState call reaps it.
+	p.cleanupLocked()
 	return nil
 }
 
-func (r *HummReplyPather) ReplyPathTo(
+func (p *HummReplyPather) ReplyPathTo(
 	sourceId snet.SourceIdentifier,
 	rpath snet.RawPath,
 ) (snet.DataplanePath, error) {
-	// If we have a valid reversed reservation for this source,
-	// return it already without reversing the current passed path.
-	// This reversed reservation might have been constructed many packets ago.
-	if rsv, ok := r.reservations[sourceId]; ok {
-		return rsv, nil
+	p.mu.Lock()
+	entry, ok := p.reservations[sourceId] // Find a reverse reservation (if any) for this source.
+	p.mu.Unlock()
+
+	if ok {
+		// If we have a valid reversed reservation for this source,
+		// return it already without reversing the current passed path.
+		// This reversed reservation might have been constructed many packets ago.
+		return entry.rsv, nil
 	}
 
 	// Otherwise, just reverse the hummingbird path.
-	return r.ReplyPath(rpath)
+	return p.ReplyPath(rpath)
+}
+
+// cleanupLocked removes every reservations entry whose expiry time has passed. p.mu must be
+// held by the caller.
+func (p *HummReplyPather) cleanupLocked() {
+	now := p.Now()
+	for p.expirations.Len() > 0 && !p.expirations[0].expiry.After(now) {
+		stale := heap.Pop(&p.expirations).(expiryItem)
+		// The reservations entry for this source may have been overwritten by a later
+		// SetState call after this heap entry was pushed; only delete it if it is still the
+		// same entry this heap entry refers to.
+		if entry, ok := p.reservations[stale.srcId]; ok && entry.expiry.Equal(stale.expiry) {
+			delete(p.reservations, stale.srcId)
+		}
+	}
 }
 
 // ReplyPath uses the embedded backup DefaultReplyPather to return the reply path.
-func (r *HummReplyPather) ReplyPath(rpath snet.RawPath) (snet.DataplanePath, error) {
-	return r.BackupRepyPather.ReplyPath(rpath)
+func (p *HummReplyPather) ReplyPath(rpath snet.RawPath) (snet.DataplanePath, error) {
+	return p.BackupRepyPather.ReplyPath(rpath)
 }
 
 // containedReversePathState extracts the reverse path information reservation option from the
@@ -93,4 +184,27 @@ func containedReversePathState(opts []*slayers.EndToEndOption) []byte {
 		}
 	}
 	return nil
+}
+
+// expiryHeap is a container/heap.Interface min-heap of expiryItem ordered by expiry time.
+type expiryHeap []expiryItem
+
+func (h expiryHeap) Len() int           { return len(h) }
+func (h expiryHeap) Less(i, j int) bool { return h[i].expiry.Before(h[j].expiry) }
+func (h expiryHeap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+func (h *expiryHeap) Push(x any) {
+	*h = append(*h, x.(expiryItem))
+}
+func (h *expiryHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[:n-1]
+	return item
+}
+
+// expiryItem is an entry in the expiryHeap.
+type expiryItem struct {
+	srcId  snet.SourceIdentifier
+	expiry time.Time
 }

--- a/pkg/snet/path/hummingbird_reply_pather.go
+++ b/pkg/snet/path/hummingbird_reply_pather.go
@@ -15,18 +15,18 @@
 package path
 
 import (
-	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/slayers"
 	"github.com/scionproto/scion/pkg/snet"
 )
 
 type HummReplyPather struct {
-	// origSrcIA is the original source IA of the packet (the "sender" when setting the
-	// state of the reply pather via a packet).
-	origSrcIA addr.IA
-	// reservation is the Hummingbird path in the already reversed direction, src IA is this IA.
-	reservation      *Reservation
 	BackupRepyPather snet.ReplyPather // Used if no bidirectional reservation is available.
+
+	// reservations maintains a Hummingbird Reservation to each source who has sent a reverse
+	// reservation to reach them. It is populated by SetState.
+	reservations map[snet.SourceIdentifier]*Reservation
+
+	// TODO clean the reservation map via a configurable callback.
 }
 
 var _ snet.StatefulReplyPather = (*HummReplyPather)(nil)
@@ -36,6 +36,7 @@ var _ snet.StatefulReplyPather = (*HummReplyPather)(nil)
 func NewHummReplyPather() *HummReplyPather {
 	return &HummReplyPather{
 		BackupRepyPather: snet.DefaultReplyPather{},
+		reservations:     make(map[snet.SourceIdentifier]*Reservation),
 	}
 }
 
@@ -43,10 +44,7 @@ func NewHummReplyPather() *HummReplyPather {
 // reservation. Being this reply pather run at AS A, the state is set when a packet is received
 // by A from B, i.e. B->A. This packet contains some end2end extension options with the necessary
 // serialized reservation state to reconstruct a valid reverse Reservation.
-func (p *HummReplyPather) SetState(pkt snet.Packet) error {
-	// Record the sender.
-	p.origSrcIA = pkt.Source.IA
-
+func (p *HummReplyPather) SetState(sourceId snet.SourceIdentifier, pkt snet.Packet) error {
 	// Check if there is any bidirectional reservation information in this packet.
 	serializedReservation := containedReversePathState(pkt.E2eExtnContents)
 	if serializedReservation == nil {
@@ -56,23 +54,33 @@ func (p *HummReplyPather) SetState(pkt snet.Packet) error {
 
 	// Build the reverse reservation.
 	originalPath := pkt.Path.(snet.RawPath) // Can't fail, it was checked by the caller.
-	var err error
-	p.reservation, err = NewReservation(
-		WithReverseFromBidirectional(serializedReservation, originalPath, p.origSrcIA))
+	rsv, err := NewReservation(
+		WithReverseFromBidirectional(serializedReservation, originalPath, pkt.Source.IA))
 	if err != nil {
 		return err
 	}
+
+	p.reservations[sourceId] = rsv
 	return nil
 }
 
-func (r *HummReplyPather) ReplyPath(rpath snet.RawPath) (snet.DataplanePath, error) {
-	// If we have a valid reversed reservation, return it already without reversing the current
-	// passed path. This reversed reservation might have been constructed many packets ago.
-	if r.reservation != nil {
-		return r.reservation, nil
+func (r *HummReplyPather) ReplyPathTo(
+	sourceId snet.SourceIdentifier,
+	rpath snet.RawPath,
+) (snet.DataplanePath, error) {
+	// If we have a valid reversed reservation for this source,
+	// return it already without reversing the current passed path.
+	// This reversed reservation might have been constructed many packets ago.
+	if rsv, ok := r.reservations[sourceId]; ok {
+		return rsv, nil
 	}
 
 	// Otherwise, just reverse the hummingbird path.
+	return r.ReplyPath(rpath)
+}
+
+// ReplyPath uses the embedded backup DefaultReplyPather to return the reply path.
+func (r *HummReplyPather) ReplyPath(rpath snet.RawPath) (snet.DataplanePath, error) {
 	return r.BackupRepyPather.ReplyPath(rpath)
 }
 

--- a/pkg/snet/path/hummingbird_reply_pather_test.go
+++ b/pkg/snet/path/hummingbird_reply_pather_test.go
@@ -15,8 +15,10 @@
 package path_test
 
 import (
+	"fmt"
 	"net/netip"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	dpscion "github.com/scionproto/scion/pkg/slayers/path/scion"
 	"github.com/scionproto/scion/pkg/snet"
 	"github.com/scionproto/scion/pkg/snet/path"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,7 +99,7 @@ func TestHummReplyPather(t *testing.T) {
 	for name, tc := range cases {
 		name, tc := name, tc
 		t.Run(name, func(t *testing.T) {
-			rp := path.NewHummReplyPather()
+			rp := path.NewHummReplyPather(path.WithClock(func() time.Time { return timestamp }))
 			if tc.packet != nil {
 				err := rp.SetState(tc.srcId, *tc.packet)
 				if tc.wantSetStateErr {
@@ -156,6 +159,250 @@ func TestHummReplyPather(t *testing.T) {
 	}
 }
 
+// TestHummReplyPatherMultipleClients checks that HummReplyPather keeps one
+// cached reservation per distinct source (identified by the IA, IP, port
+// triplet), and that clients are never cross-contaminated even when they
+// partially share IA or port with another client.
+func TestHummReplyPatherMultipleClients(t *testing.T) {
+	timestampA := util.SecsToTime(123456)
+	timestampB := util.SecsToTime(654321)
+
+	clientA := snet.SourceIdentifier{
+		IA:   addr.MustParseIA("1-ff00:0:111"),
+		IP:   mustParseIp(t, "10.0.0.2"),
+		Port: 12345,
+	}
+	// clientB differs from clientA in every element of the triplet.
+	clientB := snet.SourceIdentifier{
+		IA:   addr.MustParseIA("1-ff00:0:112"),
+		IP:   mustParseIp(t, "10.0.0.3"),
+		Port: 54321,
+	}
+	// clientC shares clientA's IA and port but not its IP: the triplet as a whole must still
+	// be treated as a distinct source.
+	clientC := snet.SourceIdentifier{
+		IA:   clientA.IA,
+		IP:   mustParseIp(t, "10.0.0.9"),
+		Port: clientA.Port,
+	}
+
+	carrierPathA := mustRawHummingbirdPathForReplyPather(t, timestampA)
+	carrierPathB := mustRawHummingbirdPathForReplyPather(t, timestampB)
+	stateA := mustSerializedReverseReservationState(t, timestampA)
+	stateB := mustSerializedReverseReservationState(t, timestampB)
+
+	rp := path.NewHummReplyPather(path.WithClock(func() time.Time { return timestampA }))
+
+	// Only A and B ever call SetState; C never does.
+	require.NoError(t, rp.SetState(clientA, *packetWithReverseState(clientA, carrierPathA, stateA)))
+	require.NoError(t, rp.SetState(clientB, *packetWithReverseState(clientB, carrierPathB, stateB)))
+
+	gotA, err := rp.ReplyPathTo(clientA, cloneRawPath(carrierPathA))
+	require.NoError(t, err)
+	rsvA, ok := gotA.(*path.Reservation)
+	require.True(t, ok, "expected cached reservation for clientA, got %T", gotA)
+
+	gotB, err := rp.ReplyPathTo(clientB, cloneRawPath(carrierPathB))
+	require.NoError(t, err)
+	rsvB, ok := gotB.(*path.Reservation)
+	require.True(t, ok, "expected cached reservation for clientB, got %T", gotB)
+
+	// Each client's cached reservation must reflect its own reverse state.
+	wantA := mustReservationFromReverseState(t, carrierPathA, stateA, clientA.IA)
+	wantB := mustReservationFromReverseState(t, carrierPathB, stateB, clientB.IA)
+	require.Equal(t, mustSerializeReservation(t, wantA), mustSerializeReservation(t, rsvA))
+	require.Equal(t, mustSerializeReservation(t, wantB), mustSerializeReservation(t, rsvB))
+	require.NotEqual(t,
+		mustSerializeReservation(t, rsvA),
+		mustSerializeReservation(t, rsvB),
+		"distinct clients must not share a cached reservation",
+	)
+
+	// clientC never called SetState, so it must fall back to the default reply pather rather
+	// than picking up clientA's cached reservation, even though it shares A's IA and port.
+	gotC, err := rp.ReplyPathTo(clientC, cloneRawPath(carrierPathA))
+	require.NoError(t, err)
+	_, isReservation := gotC.(*path.Reservation)
+	require.False(t, isReservation, "clientC must not receive clientA's cached reservation")
+}
+
+// TestHummReplyPatherConcurrent exercises SetState and ReplyPathTo from many goroutines at once,
+// each acting as a distinct client. Run with -race to confirm there is no data race on the
+// shared reservation cache.
+func TestHummReplyPatherConcurrent(t *testing.T) {
+	const numClients = 50
+	const itersPerClient = 20
+
+	timestamp := util.SecsToTime(123456)
+	rp := path.NewHummReplyPather(path.WithClock(func() time.Time { return timestamp }))
+
+	type client struct {
+		srcId       snet.SourceIdentifier
+		carrierPath snet.RawPath
+		state       []byte
+	}
+	clients := make([]client, numClients)
+	for i := range clients {
+		clients[i] = client{
+			srcId: snet.SourceIdentifier{
+				IA:   addr.MustParseIA("1-ff00:0:111"),
+				IP:   mustParseIp(t, "10.0.0.2"),
+				Port: uint16(20000 + i),
+			},
+			carrierPath: mustRawHummingbirdPathForReplyPather(t, timestamp),
+			state:       mustSerializedReverseReservationState(t, timestamp),
+		}
+	}
+
+	var wg sync.WaitGroup
+	for _, c := range clients {
+		c := c
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < itersPerClient; i++ {
+				pkt := packetWithReverseState(c.srcId, c.carrierPath, c.state)
+				if !assert.NoError(t, rp.SetState(c.srcId, *pkt)) {
+					return
+				}
+				got, err := rp.ReplyPathTo(c.srcId, cloneRawPath(c.carrierPath))
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.IsType(t, (*path.Reservation)(nil), got)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// After every goroutine settles, each client must still have its own valid cached
+	// reservation, independent of how many other clients were being served concurrently.
+	for _, c := range clients {
+		got, err := rp.ReplyPathTo(c.srcId, cloneRawPath(c.carrierPath))
+		require.NoError(t, err)
+		require.IsType(t, (*path.Reservation)(nil), got)
+	}
+}
+
+// TestHummReplyPatherCleanup checks that cleanup is tied to SetState's insertion of a new
+// entry rather than to ReplyPathTo lookups: a reservation past its own expiry+slack keeps being
+// served by ReplyPathTo until some later SetState call (for any source) sweeps it away.
+func TestHummReplyPatherCleanup(t *testing.T) {
+	start := util.SecsToTime(1_000_000)
+	now := start
+	clock := func() time.Time { return now }
+
+	const slack = 5 * time.Second
+	rp := path.NewHummReplyPather(path.WithClock(clock), path.WithCleanupSlack(slack))
+
+	srcId := snet.SourceIdentifier{
+		IA:   addr.MustParseIA("1-ff00:0:111"),
+		IP:   mustParseIp(t, "10.0.0.2"),
+		Port: 12345,
+	}
+	carrierPath := mustRawHummingbirdPathForReplyPather(t, start)
+	state := mustSerializedReverseReservationState(t, start)
+	require.NoError(t, rp.SetState(srcId, *packetWithReverseState(srcId, carrierPath, state)))
+
+	// The fixture's flyovers have a 10s duration (see createFlyoverForReplyPather), so the
+	// reservation's own expiry is start+10s; with slack it becomes eligible for cleanup at
+	// start+10s+slack.
+	got, err := rp.ReplyPathTo(srcId, cloneRawPath(carrierPath))
+	require.NoError(t, err)
+	require.IsType(t, (*path.Reservation)(nil), got, "reservation should still be cached")
+
+	// Advance time past expiry + slack. ReplyPathTo performs no cleanup on its own, so the
+	// now-stale entry must still be returned: eviction only happens on the next SetState call.
+	now = start.Add(10*time.Second + slack).Add(time.Millisecond)
+	got, err = rp.ReplyPathTo(srcId, cloneRawPath(carrierPath))
+	require.NoError(t, err)
+	require.IsType(t, (*path.Reservation)(nil), got,
+		"ReplyPathTo alone must not evict a stale entry; cleanup is tied to SetState")
+
+	// A SetState call for an unrelated source triggers the global cleanup sweep, which
+	// evicts srcId's now-stale entry as a side effect.
+	otherSrcId := snet.SourceIdentifier{
+		IA:   addr.MustParseIA("1-ff00:0:112"),
+		IP:   mustParseIp(t, "10.0.0.3"),
+		Port: 54321,
+	}
+	otherCarrierPath := mustRawHummingbirdPathForReplyPather(t, now)
+	otherState := mustSerializedReverseReservationState(t, now)
+	require.NoError(t, rp.SetState(
+		otherSrcId, *packetWithReverseState(otherSrcId, otherCarrierPath, otherState)))
+
+	got, err = rp.ReplyPathTo(srcId, cloneRawPath(carrierPath))
+	require.NoError(t, err)
+	_, isReservation := got.(*path.Reservation)
+	require.False(t, isReservation,
+		"srcId's reservation should have been evicted by the SetState-triggered sweep")
+
+	want, wantErr := snet.DefaultReplyPather{}.ReplyPath(cloneRawPath(carrierPath))
+	require.NoError(t, wantErr)
+	require.Equal(t, want, got)
+}
+
+// BenchmarkHummReplyPatherCleanup measures the cost of evicting n already-expired reservations
+// from the cache in a single SetState call, for growing values of n. Cleanup is tied to
+// insertion: every SetState call that adds a new entry also sweeps every expired entry at
+// once (not just the calling source's), so this is the operation whose cost scales with how
+// many distinct clients had entries pending eviction.
+//
+// The n entries must be recreated before every measured call, since cleanup empties the cache;
+// that setup is deliberately left inside the benchmark's own timer (rather than excluded via
+// b.StopTimer/b.StartTimer) so Go's duration-based auto-scaling picks a b.N inversely
+// proportional to the true per-iteration cost, keeping the total run time bounded regardless of
+// n. The cost of the triggering SetState call alone is measured separately and reported as the
+// custom "ns/entry" metric.
+func BenchmarkHummReplyPatherCleanup(b *testing.B) {
+	for _, n := range []int{1, 10, 100, 1_000} {
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			start := util.SecsToTime(1_000_000)
+			carrierPath := mustRawHummingbirdPathForReplyPather(b, start)
+			state := mustSerializedReverseReservationState(b, start)
+			ia := addr.MustParseIA("1-ff00:0:111")
+			ip := mustParseIp(b, "10.0.0.2")
+
+			srcIds := make([]snet.SourceIdentifier, n)
+			for i := range srcIds {
+				// Varying only the port is enough to make each entry a distinct map key.
+				srcIds[i] = snet.SourceIdentifier{IA: ia, IP: ip, Port: uint16(i)}
+			}
+			// A source distinct from all of srcIds, used only to trigger the measured
+			// SetState call that performs the cleanup sweep.
+			triggerSrcId := snet.SourceIdentifier{IA: ia, IP: ip, Port: uint16(n)}
+
+			var cleanupNanos int64
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				now := start
+				rp := path.NewHummReplyPather(path.WithClock(func() time.Time { return now }))
+				for _, srcId := range srcIds {
+					pkt := packetWithReverseState(srcId, carrierPath, state)
+					if err := rp.SetState(srcId, *pkt); err != nil {
+						b.Fatal(err)
+					}
+				}
+				// Advance time well past every entry's expiry+slack so the next SetState
+				// call must evict all n of them in a single sweep.
+				now = start.Add(time.Hour)
+				triggerPkt := packetWithReverseState(triggerSrcId, carrierPath, state)
+
+				cleanupStart := time.Now()
+				if err := rp.SetState(triggerSrcId, *triggerPkt); err != nil {
+					b.Fatal(err)
+				}
+				cleanupNanos += time.Since(cleanupStart).Nanoseconds()
+			}
+			entries := n
+			if entries == 0 {
+				entries = 1
+			}
+			b.ReportMetric(float64(cleanupNanos)/float64(b.N*entries), "ns/entry")
+		})
+	}
+}
+
 // packetWithoutReverseState builds a packet whose SetState call should behave
 // like a no-op for reverse-reservation caching.
 func packetWithoutReverseState(
@@ -205,7 +452,7 @@ func packetWithReverseState(
 
 // mustRawSCIONPathForReplyPather serializes the synthetic SCION path fixture
 // used by the reply-pather tests into an snet.RawPath.
-func mustRawSCIONPathForReplyPather(t *testing.T, when time.Time) snet.RawPath {
+func mustRawSCIONPathForReplyPather(t testing.TB, when time.Time) snet.RawPath {
 	t.Helper()
 
 	dec := createScionPathForReplyPather(when)
@@ -219,7 +466,7 @@ func mustRawSCIONPathForReplyPather(t *testing.T, when time.Time) snet.RawPath {
 
 // mustRawHummingbirdPathForReplyPather serializes the synthetic Hummingbird path
 // fixture used by the reply-pather tests into an snet.RawPath.
-func mustRawHummingbirdPathForReplyPather(t *testing.T, when time.Time) snet.RawPath {
+func mustRawHummingbirdPathForReplyPather(t testing.TB, when time.Time) snet.RawPath {
 	t.Helper()
 
 	dec := createHummingbirdPathForReplyPather(when)
@@ -233,7 +480,7 @@ func mustRawHummingbirdPathForReplyPather(t *testing.T, when time.Time) snet.Raw
 
 // mustRawEPICPath wraps the synthetic SCION fixture in an EPIC path so the
 // fallback reply-path logic can be exercised on EPIC inputs.
-func mustRawEPICPath(t *testing.T, when time.Time) snet.RawPath {
+func mustRawEPICPath(t testing.TB, when time.Time) snet.RawPath {
 	t.Helper()
 
 	scionDecoded := createScionPathForReplyPather(when)
@@ -258,7 +505,7 @@ func mustRawEPICPath(t *testing.T, when time.Time) snet.RawPath {
 
 // mustRawOneHopPath builds a supported non-SCION, non-Hummingbird fallback
 // input for reply-path tests.
-func mustRawOneHopPath(t *testing.T, when time.Time) snet.RawPath {
+func mustRawOneHopPath(t testing.TB, when time.Time) snet.RawPath {
 	t.Helper()
 
 	p := onehop.Path{
@@ -287,7 +534,7 @@ func mustRawOneHopPath(t *testing.T, when time.Time) snet.RawPath {
 
 // mustSerializedReverseReservationState creates the serialized reverse
 // reservation state consumed by HummReplyPather.SetState.
-func mustSerializedReverseReservationState(t *testing.T, when time.Time) []byte {
+func mustSerializedReverseReservationState(t testing.TB, when time.Time) []byte {
 	t.Helper()
 
 	srcIA := addr.MustParseIA("1-ff00:0:111")
@@ -330,7 +577,7 @@ func mustSerializedReverseReservationState(t *testing.T, when time.Time) []byte 
 // mustReservationFromReverseState reconstructs the reservation that SetState is
 // expected to cache for successful bidirectional-reply setup.
 func mustReservationFromReverseState(
-	t *testing.T,
+	t testing.TB,
 	carrierPath snet.RawPath,
 	state []byte,
 	dstIA addr.IA,
@@ -346,7 +593,7 @@ func mustReservationFromReverseState(
 
 // mustReversedSCIONPathForReplyPather creates the reversed SCION dataplane path
 // used to synthesize reverse reservation state.
-func mustReversedSCIONPathForReplyPather(t *testing.T, when time.Time) path.SCION {
+func mustReversedSCIONPathForReplyPather(t testing.TB, when time.Time) path.SCION {
 	t.Helper()
 
 	dec := createScionPathForReplyPather(when)
@@ -361,7 +608,7 @@ func mustReversedSCIONPathForReplyPather(t *testing.T, when time.Time) path.SCIO
 
 // mustSerializeReservation encodes a reservation into its wire-format state for
 // stable equality assertions.
-func mustSerializeReservation(t *testing.T, reservation *path.Reservation) []byte {
+func mustSerializeReservation(t testing.TB, reservation *path.Reservation) []byte {
 	t.Helper()
 
 	raw := make([]byte, reservation.SerializedLen())
@@ -371,7 +618,7 @@ func mustSerializeReservation(t *testing.T, reservation *path.Reservation) []byt
 
 // mustSerializeSlayersPath encodes a decoded slayers path into bytes so tests
 // can compare reply-path results independently of concrete Go values.
-func mustSerializeSlayersPath(t *testing.T, p dppath.Path) []byte {
+func mustSerializeSlayersPath(t testing.TB, p dppath.Path) []byte {
 	t.Helper()
 
 	if p == nil {
@@ -499,7 +746,7 @@ func createFlyoverForReplyPather(startTime uint32) *path.FlyoverData {
 	}
 }
 
-func mustParseIp(t *testing.T, ip string) netip.Addr {
+func mustParseIp(t testing.TB, ip string) netip.Addr {
 	a, err := netip.ParseAddr(ip)
 	require.NoError(t, err)
 	return a

--- a/pkg/snet/path/hummingbird_reply_pather_test.go
+++ b/pkg/snet/path/hummingbird_reply_pather_test.go
@@ -15,6 +15,7 @@
 package path_test
 
 import (
+	"net/netip"
 	"reflect"
 	"testing"
 	"time"
@@ -38,7 +39,11 @@ import (
 // snet.DefaultReplyPather for reply-path construction.
 func TestHummReplyPather(t *testing.T) {
 	timestamp := util.SecsToTime(123456)
-	srcIA := addr.MustParseIA("1-ff00:0:111")
+	srcId := snet.SourceIdentifier{
+		IA:   addr.MustParseIA("1-ff00:0:111"),
+		IP:   mustParseIp(t, "10.0.0.2"),
+		Port: 12345,
+	}
 	carrierPath := mustRawHummingbirdPathForReplyPather(t, timestamp)
 	validReverseState := mustSerializedReverseReservationState(t, timestamp)
 
@@ -55,26 +60,35 @@ func TestHummReplyPather(t *testing.T) {
 	// expected to install a cached reverse reservation.
 	cases := map[string]struct {
 		packet                *snet.Packet
+		srcId                 snet.SourceIdentifier
 		wantSetStateErr       bool
 		wantCachedReservation bool
 	}{
 		"never_set_state": {},
 		"set_state_invalid_packet/no_reverse_option": {
-			packet:                packetWithoutReverseState(srcIA, carrierPath),
+			packet:                packetWithoutReverseState(srcId, carrierPath),
+			srcId:                 srcId,
 			wantCachedReservation: false,
 		},
 		"set_state_invalid_packet/non_hummingbird_carrier": {
-			packet:                packetWithReverseState(srcIA, mustRawSCIONPathForReplyPather(t, timestamp), validReverseState),
+			packet: packetWithReverseState(
+				srcId,
+				mustRawSCIONPathForReplyPather(t, timestamp),
+				validReverseState),
+			srcId:                 srcId,
 			wantSetStateErr:       true,
 			wantCachedReservation: false,
 		},
 		"set_state_invalid_packet/bad_serialized_state": {
-			packet:                packetWithReverseState(srcIA, carrierPath, []byte{0xde, 0xad, 0xbe, 0xef}),
+			packet: packetWithReverseState(srcId,
+				carrierPath, []byte{0xde, 0xad, 0xbe, 0xef}),
+			srcId:                 srcId,
 			wantSetStateErr:       true,
 			wantCachedReservation: false,
 		},
 		"set_state_valid_packet": {
-			packet:                packetWithReverseState(srcIA, carrierPath, validReverseState),
+			packet:                packetWithReverseState(srcId, carrierPath, validReverseState),
+			srcId:                 srcId,
 			wantCachedReservation: true,
 		},
 	}
@@ -84,7 +98,7 @@ func TestHummReplyPather(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			rp := path.NewHummReplyPather()
 			if tc.packet != nil {
-				err := rp.SetState(*tc.packet)
+				err := rp.SetState(tc.srcId, *tc.packet)
 				if tc.wantSetStateErr {
 					require.Error(t, err)
 				} else {
@@ -95,7 +109,7 @@ func TestHummReplyPather(t *testing.T) {
 			for replyName, input := range replyInputs {
 				replyName, input := replyName, input
 				t.Run(replyName, func(t *testing.T) {
-					got, err := rp.ReplyPath(cloneRawPath(input))
+					got, err := rp.ReplyPathTo(tc.srcId, cloneRawPath(input))
 					if tc.wantCachedReservation {
 						// Once a valid reverse reservation is cached, reply-path
 						// selection should no longer depend on the incoming path type.
@@ -103,7 +117,11 @@ func TestHummReplyPather(t *testing.T) {
 						gotReservation, ok := got.(*path.Reservation)
 						require.True(t, ok, "expected cached reservation, got %T", got)
 
-						wantReservation := mustReservationFromReverseState(t, carrierPath, validReverseState, srcIA)
+						wantReservation := mustReservationFromReverseState(
+							t,
+							carrierPath,
+							validReverseState,
+							tc.srcId.IA)
 						require.Equal(t, wantReservation.DstIA, gotReservation.DstIA)
 						require.Len(t, gotReservation.Hops, len(wantReservation.Hops))
 						require.Equal(t, wantReservation.Dec.Type(), gotReservation.Dec.Type())
@@ -136,30 +154,26 @@ func TestHummReplyPather(t *testing.T) {
 			}
 		})
 	}
-
-	// Nil receivers are currently unsupported; document the panic contract
-	// explicitly so future changes are intentional.
-	t.Run("nil_receiver", func(t *testing.T) {
-		var rp *path.HummReplyPather
-		pkt := *packetWithoutReverseState(srcIA, carrierPath)
-		rpath := mustRawSCIONPathForReplyPather(t, timestamp)
-
-		require.Panics(t, func() {
-			_ = rp.SetState(pkt)
-		})
-		require.Panics(t, func() {
-			_, _ = rp.ReplyPath(rpath)
-		})
-	})
 }
 
 // packetWithoutReverseState builds a packet whose SetState call should behave
 // like a no-op for reverse-reservation caching.
-func packetWithoutReverseState(srcIA addr.IA, carrierPath snet.RawPath) *snet.Packet {
+func packetWithoutReverseState(
+	srcId snet.SourceIdentifier,
+	carrierPath snet.RawPath,
+) *snet.Packet {
 	return &snet.Packet{
 		PacketInfo: snet.PacketInfo{
-			Source: snet.SCIONAddress{IA: srcIA},
-			Path:   carrierPath,
+			Source: snet.SCIONAddress{
+				IA:   srcId.IA,
+				Host: addr.HostIP(srcId.IP),
+			},
+			Path: carrierPath,
+			Payload: snet.UDPPayload{
+				SrcPort: srcId.Port,
+				DstPort: 42,
+				Payload: ([]byte)("mock payload"),
+			},
 		},
 	}
 }
@@ -174,19 +188,19 @@ func cloneRawPath(rpath snet.RawPath) snet.RawPath {
 
 // packetWithReverseState builds a packet that carries reverse reservation state
 // in an end-to-end option.
-func packetWithReverseState(srcIA addr.IA, carrierPath snet.RawPath, state []byte) *snet.Packet {
-	return &snet.Packet{
-		PacketInfo: snet.PacketInfo{
-			Source: snet.SCIONAddress{IA: srcIA},
-			Path:   carrierPath,
-			E2eExtnContents: []*slayers.EndToEndOption{
-				{
-					OptType: slayers.OptTypeReversePath,
-					OptData: append([]byte(nil), state...),
-				},
-			},
+func packetWithReverseState(
+	srcId snet.SourceIdentifier,
+	carrierPath snet.RawPath,
+	state []byte,
+) *snet.Packet {
+	pkt := packetWithoutReverseState(srcId, carrierPath)
+	pkt.E2eExtnContents = []*slayers.EndToEndOption{
+		{
+			OptType: slayers.OptTypeReversePath,
+			OptData: append([]byte(nil), state...),
 		},
 	}
+	return pkt
 }
 
 // mustRawSCIONPathForReplyPather serializes the synthetic SCION path fixture
@@ -483,4 +497,10 @@ func createFlyoverForReplyPather(startTime uint32) *path.FlyoverData {
 		Bw:        64,
 		Ak:        [16]byte{1, 2, 3, 4},
 	}
+}
+
+func mustParseIp(t *testing.T, ip string) netip.Addr {
+	a, err := netip.ParseAddr(ip)
+	require.NoError(t, err)
+	return a
 }

--- a/pkg/snet/path/hummingbird_reply_pather_test.go
+++ b/pkg/snet/path/hummingbird_reply_pather_test.go
@@ -49,6 +49,7 @@ func TestHummReplyPather(t *testing.T) {
 	}
 	carrierPath := mustRawHummingbirdPathForReplyPather(t, timestamp)
 	validReverseState := mustSerializedReverseReservationState(t, timestamp)
+	validReverseStateNoFlyovers := mustSerializedReverseReservationStateNoFlyovers(t, timestamp)
 
 	// Exercise the fallback reply-pather behavior with the main path families
 	// supported by DefaultReplyPather.
@@ -93,6 +94,13 @@ func TestHummReplyPather(t *testing.T) {
 			packet:                packetWithReverseState(srcId, carrierPath, validReverseState),
 			srcId:                 srcId,
 			wantCachedReservation: true,
+		},
+		"set_state_valid_packet/no_flyovers": {
+			// A reverse reservation with no flyovers offers nothing beyond reversing the
+			// transport path directly, so it must not be cached.
+			packet:                packetWithReverseState(srcId, carrierPath, validReverseStateNoFlyovers),
+			srcId:                 srcId,
+			wantCachedReservation: false,
 		},
 	}
 
@@ -342,6 +350,46 @@ func TestHummReplyPatherCleanup(t *testing.T) {
 	require.Equal(t, want, got)
 }
 
+// TestHummReplyPatherSetStateNoFlyoversEvictsCachedReservation checks that a SetState call
+// carrying a valid but flyover-less reverse reservation for a source that already has a cached
+// reservation immediately evicts that cached entry, rather than leaving it to be served (or to
+// be reaped incidentally by some later, unrelated SetState call).
+func TestHummReplyPatherSetStateNoFlyoversEvictsCachedReservation(t *testing.T) {
+	timestamp := util.SecsToTime(123456)
+	rp := path.NewHummReplyPather(path.WithClock(func() time.Time { return timestamp }))
+
+	srcId := snet.SourceIdentifier{
+		IA:   addr.MustParseIA("1-ff00:0:111"),
+		IP:   mustParseIp(t, "10.0.0.2"),
+		Port: 12345,
+	}
+	carrierPath := mustRawHummingbirdPathForReplyPather(t, timestamp)
+
+	// First, install a cached reservation via a valid reverse state with flyovers.
+	state := mustSerializedReverseReservationState(t, timestamp)
+	require.NoError(t, rp.SetState(srcId, *packetWithReverseState(srcId, carrierPath, state)))
+
+	got, err := rp.ReplyPathTo(srcId, cloneRawPath(carrierPath))
+	require.NoError(t, err)
+	require.IsType(t, (*path.Reservation)(nil), got, "reservation should be cached")
+
+	// The same source now sends a valid reverse state, but with no flyovers. SetState must
+	// not cache it (as checked elsewhere), and must also evict the stale entry it supersedes.
+	stateNoFlyovers := mustSerializedReverseReservationStateNoFlyovers(t, timestamp)
+	require.NoError(t, rp.SetState(
+		srcId, *packetWithReverseState(srcId, carrierPath, stateNoFlyovers)))
+
+	got, err = rp.ReplyPathTo(srcId, cloneRawPath(carrierPath))
+	require.NoError(t, err)
+	_, isReservation := got.(*path.Reservation)
+	require.False(t, isReservation,
+		"the previously cached reservation should have been evicted")
+
+	want, wantErr := snet.DefaultReplyPather{}.ReplyPath(cloneRawPath(carrierPath))
+	require.NoError(t, wantErr)
+	require.Equal(t, want, got)
+}
+
 // BenchmarkHummReplyPatherCleanup measures the cost of evicting n already-expired reservations
 // from the cache in a single SetState call, for growing values of n. Cleanup is tied to
 // insertion: every SetState call that adds a new entry also sweeps every expired entry at
@@ -563,6 +611,48 @@ func mustSerializedReverseReservationState(t testing.TB, when time.Time) []byte 
 				Egress:  0,
 			},
 			Flyover: createFlyoverForReplyPather(uint32(when.Unix())),
+		},
+	}
+
+	reservation, err := path.NewReservation(
+		path.WithDataplanePath(reverseSCION, srcIA, reverseHops),
+		path.WithNow(func() time.Time { return when }),
+	)
+	require.NoError(t, err)
+	return mustSerializeReservation(t, reservation)
+}
+
+// mustSerializedReverseReservationStateNoFlyovers is identical to
+// mustSerializedReverseReservationState except none of its hops carry a flyover, so the
+// resulting Reservation's Expiry is the zero Time. It is used to check that HummReplyPather
+// rejects caching such a reservation, since it offers nothing beyond reversing the transport
+// path directly.
+func mustSerializedReverseReservationStateNoFlyovers(t testing.TB, when time.Time) []byte {
+	t.Helper()
+
+	srcIA := addr.MustParseIA("1-ff00:0:111")
+	reverseSCION := mustReversedSCIONPathForReplyPather(t, when)
+	reverseHops := path.FlyoverSequence{
+		{
+			BaseHop: path.BaseHop{
+				IA:      addr.MustParseIA("1-ff00:0:112"),
+				Ingress: 0,
+				Egress:  1,
+			},
+		},
+		{
+			BaseHop: path.BaseHop{
+				IA:      addr.MustParseIA("1-ff00:0:110"),
+				Ingress: 2,
+				Egress:  1,
+			},
+		},
+		{
+			BaseHop: path.BaseHop{
+				IA:      addr.MustParseIA("1-ff00:0:111"),
+				Ingress: 41,
+				Egress:  0,
+			},
 		},
 	}
 

--- a/pkg/snet/reader.go
+++ b/pkg/snet/reader.go
@@ -15,7 +15,6 @@
 package snet
 
 import (
-	"fmt"
 	"net"
 	"net/netip"
 	"sync"
@@ -98,7 +97,6 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 	// If this were ever to change, we would always fall into the following if statement, then
 	// we would like to replace this logic (e.g., using IP_PKTINFO, with its caveats).
 	if c.local.Host.AddrPort() != pktAddrPort {
-
 		// If the client is behind a NAT, the SCION packet will hold the mapped external address,
 		// which is expected to be different from the local address. To handle this case, we check
 		// whether the underlying connection is a stunConn, which indicates that NAT traversal
@@ -121,18 +119,20 @@ func (c *scionConnReader) read(b []byte) (int, *UDPAddr, error) {
 	}
 
 	// Using the reply pather, build the reverse path.
-	fmt.Printf("deleteme checking if reply pather is stateful... ")
-
 	var replyPath DataplanePath
 	if statefulRP, ok := c.replyPather.(StatefulReplyPather); ok {
-		fmt.Print("yes\n")
-		if err := statefulRP.SetState(pkt); err != nil {
+		sourceId := SourceIdentifier{
+			IA:   pkt.Source.IA,
+			IP:   pkt.Source.Host.IP(),
+			Port: udp.SrcPort,
+		}
+		if err := statefulRP.SetState(sourceId, pkt); err != nil {
 			return 0, nil, serrors.Wrap("cannot set the state of the reply pather", err)
 		}
+		replyPath, err = statefulRP.ReplyPathTo(sourceId, rpath)
 	} else {
-		fmt.Print("no\n")
+		replyPath, err = c.replyPather.ReplyPath(rpath)
 	}
-	replyPath, err = c.replyPather.ReplyPath(rpath)
 	if err != nil {
 		return 0, nil, serrors.Wrap("creating reply path", err)
 	}

--- a/pkg/snet/reply_pather.go
+++ b/pkg/snet/reply_pather.go
@@ -15,6 +15,9 @@
 package snet
 
 import (
+	"net/netip"
+
+	"github.com/scionproto/scion/pkg/addr"
 	"github.com/scionproto/scion/pkg/private/serrors"
 	"github.com/scionproto/scion/pkg/slayers"
 	"github.com/scionproto/scion/pkg/slayers/path"
@@ -60,8 +63,18 @@ func (p RawReplyPath) SetPath(s *slayers.SCION) error {
 }
 
 // StatefulReplyPather represents a reply pather that can contain state.
+// The ReplyPather is kept as a singleton per SCION network and Connection.
+// all necessary state should be either independent of the
 type StatefulReplyPather interface {
 	ReplyPather
-	// SetState(srcIA addr.IA, pathFromSrc RawPath, state []byte) error
-	SetState(pkt Packet) error
+	SetState(srcId SourceIdentifier, pkt Packet) error
+	ReplyPathTo(srcId SourceIdentifier, rpath RawPath) (DataplanePath, error)
+}
+
+// SourceIdentifier is the type used to identify a particular source.
+// Two sources A and B are the same iff their IA, IP, and port are the same.
+type SourceIdentifier struct {
+	IA   addr.IA
+	IP   netip.Addr
+	Port uint16
 }


### PR DESCRIPTION
The design of snet has one `ReplyPather` per SCION network object.
The `snet.Conn` that is obtained from `Listen` or `Dial` copies this reference to its own `Conn` object.
Additionally, there is only one `Conn` object at the server, where it just obtains it after `Listen`,
and simply reads all packets, obtaining the remote address as a return value of `ReadFrom`.

Since the `HummReplyPather` keeps state per client, it has to do its own bookkeeping.
For each `Packet`, a client ID is obtained using the IA, IP, and UDP port in said packet.
For each client ID, the `HummReplyPather` can keep a reverse reservation,
if one was sent via an E2E extension header.

If the reverse reservation contains no flyovers, it is not stored; it doesn't offer better guarantees to the server than the reverse path used to carry the packet from the client to the server in the first place.
Thus it's equivalent to just reverse the regular forward path received at the server.
It would remove a previous reverse reservation for that client ID if there were any,
to make the equivalence truly complete.

This PR adds extensive tests covering the following features of the `HummReplyPather`:
- Reverse reservation per client ID.
- Concurrent use by different goroutines.
- Cleanup of old (_very_ expired) reverse reservations: avoids the memory consumption to grow forever.
- Reverse reservations without flyovers do nothing, or clean a previous reverse reservation, even if not expired.
- Cleanup happens at the `SetState` function: the only place where the storage grows, now also ensures it can shrink.
- Benchmark of the cost of cleaning up expired reservations: on a old desktop machine, between 200-800ns, depending on the number of existing reservations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/juagargi/scion/66)
<!-- Reviewable:end -->
